### PR TITLE
報酬実績エンティティからidを削除した

### DIFF
--- a/backend/src/features/records/income/domain/entity.ts
+++ b/backend/src/features/records/income/domain/entity.ts
@@ -1,5 +1,3 @@
-import { ulid } from 'ulid'
-
 import type { IncomeDefinition } from '@/features/definitions/income/domain/entity'
 import type { FinancialMonth } from '@/features/financial_months/domain/entity'
 import dayjs from '@/logic/dayjs'
@@ -9,7 +7,6 @@ export type IncomeRecordUpdator = typeof IncomeRecordUpdator[number]
 
 /** 報酬実績 */
 export type IncomeRecord = {
-  id: string
   userId: string
 
   financialMonthId: FinancialMonth['id']
@@ -33,7 +30,6 @@ export const createIncomeRecord = (props: {
   } = props
 
   return {
-    id: ulid(),
     userId,
     financialMonthId,
     definitionId,

--- a/backend/src/features/records/income/domain/repository.ts
+++ b/backend/src/features/records/income/domain/repository.ts
@@ -1,7 +1,18 @@
+import type { IncomeDefinition } from '@/features/definitions/income/domain/entity'
+import type { FinancialMonth } from '@/features/financial_months/domain/entity'
+
 import type { IncomeRecord } from './entity'
 
 export interface IncomeRecordRepository {
   insertIncomeRecord(record: IncomeRecord): Promise<IncomeRecord>
-  findById(id: IncomeRecord['id']): Promise<IncomeRecord | undefined>
-  updateIncomeDefinitionValue(id: IncomeRecord['id'], value: number): Promise<IncomeRecord | undefined>
+
+  findBy(key: {
+    financialMonthId: FinancialMonth['id']
+    definitionId: IncomeDefinition['id']
+  }): Promise<IncomeRecord | undefined>
+
+  updateIncomeRecordValue(key: {
+    financialMonthId: FinancialMonth['id']
+    definitionId: IncomeDefinition['id']
+  }, value: number): Promise<IncomeRecord | undefined>
 }

--- a/backend/src/features/records/income/domain/usecase.test.ts
+++ b/backend/src/features/records/income/domain/usecase.test.ts
@@ -74,7 +74,10 @@ describe('権限まわり', () => {
   test('他人のエンティティは取得できないこと', async () => {
     const actual = await usecase.getIncomeRecord(
       dummyUsers[0],
-      dummyIncomeRecords[1].id,
+      {
+        financialMonthId: dummyIncomeRecords[1].financialMonthId,
+        definitionId: dummyIncomeRecords[1].definitionId,
+      },
     )
 
     const error = actual.isErr() ? actual.error : undefined
@@ -84,7 +87,10 @@ describe('権限まわり', () => {
   test('他人のエンティティは更新できないこと', async () => {
     const actual = await usecase.updateIncomeRecordValue(
       dummyUsers[0],
-      dummyIncomeRecords[1].id,
+      {
+        financialMonthId: dummyIncomeRecords[1].financialMonthId,
+        definitionId: dummyIncomeRecords[1].definitionId,
+      },
       200,
       'system',
     )

--- a/backend/src/features/records/income/domain/usecase.ts
+++ b/backend/src/features/records/income/domain/usecase.ts
@@ -1,5 +1,7 @@
 import { ResultAsync } from 'neverthrow'
 
+import type { IncomeDefinition } from '@/features/definitions/income/domain/entity'
+import type { FinancialMonth } from '@/features/financial_months/domain/entity'
 import type { User } from '@/features/users/domain/entity'
 
 import type { IncomeRecord, IncomeRecordUpdator } from './entity'
@@ -8,8 +10,11 @@ import type { IncomeRecordRepository } from './repository'
 export class IncomeRecordUsecaseError extends Error {}
 
 export class NoSuchItemError extends IncomeRecordUsecaseError {
-  constructor(id: IncomeRecord['id']) {
-    super(`与えられたIDに合致するアイテムが見つからない: ${id}`)
+  constructor(key: {
+    financialMonthId: FinancialMonth['id']
+    definitionId: IncomeDefinition['id']
+  }) {
+    super(`会計月度 ${key.financialMonthId} には報酬定義 ${key.definitionId} に基づく実績がない`)
   }
 }
 
@@ -22,30 +27,36 @@ export class AuthorizationError extends IncomeRecordUsecaseError {
 export interface IncomeRecordUsecase {
   /**
    * 報酬実績を取得する
-   * @param id
+   * @param key 対象の会計月度および報酬定義
    */
-  getIncomeRecord(user: User, id: IncomeRecord['id']):
+  getIncomeRecord(user: User, key: {
+    financialMonthId: FinancialMonth['id']
+    definitionId: IncomeDefinition['id']
+  }):
   ResultAsync<IncomeRecord, NoSuchItemError | AuthorizationError>
 
   /**
    * 報酬額を更新する
-   * @param id
+   * @param key 対象の会計月度および報酬定義
    * @param value 新しい値
    * @param updator 更新者
    */
   updateIncomeRecordValue(
     user: User,
-    id: IncomeRecord['id'],
+    key: {
+      financialMonthId: FinancialMonth['id']
+      definitionId: IncomeDefinition['id']
+    },
     value: number,
     updator: IncomeRecordUpdator
   ): ResultAsync<IncomeRecord, NoSuchItemError | AuthorizationError>
 }
 
 const getIncomeRecord = (repo: IncomeRecordRepository): IncomeRecordUsecase['getIncomeRecord'] =>
-  ResultAsync.fromThrowable(async (user, id) => {
-    const record = await repo.findById(id)
+  ResultAsync.fromThrowable(async (user, key) => {
+    const record = await repo.findBy(key)
     if (record === undefined) {
-      throw new NoSuchItemError(id)
+      throw new NoSuchItemError(key)
     }
 
     if (record.userId !== user.id) {
@@ -56,19 +67,19 @@ const getIncomeRecord = (repo: IncomeRecordRepository): IncomeRecordUsecase['get
   })
 
 const updateIncomeRecordValue = (repo: IncomeRecordRepository): IncomeRecordUsecase['updateIncomeRecordValue'] =>
-  ResultAsync.fromThrowable(async (user, id, value) => {
-    const stored = await repo.findById(id)
+  ResultAsync.fromThrowable(async (user, key, value) => {
+    const stored = await repo.findBy(key)
     if (stored === undefined) {
-      throw new NoSuchItemError(id)
+      throw new NoSuchItemError(key)
     }
 
     if (stored.userId !== user.id) {
       throw new AuthorizationError(user, stored)
     }
 
-    const updated = await repo.updateIncomeDefinitionValue(id, value)
+    const updated = await repo.updateIncomeRecordValue(key, value)
     if (updated === undefined) {
-      throw new NoSuchItemError(id)
+      throw new NoSuchItemError(key)
     }
 
     return updated

--- a/backend/src/features/records/income/infrastructure/entity.ts
+++ b/backend/src/features/records/income/infrastructure/entity.ts
@@ -4,7 +4,6 @@ import { IncomeRecordUpdator } from '../domain/entity'
 
 // 草
 export const IncomeRecordRecord = z.object({
-  id: z.string(),
   user_id: z.string(),
 
   financial_month_id: z.string(),

--- a/backend/src/features/records/income/infrastructure/repositoryImpl.test.ts
+++ b/backend/src/features/records/income/infrastructure/repositoryImpl.test.ts
@@ -64,14 +64,20 @@ describe('報酬定義の操作', () => {
   })
 
   test('挿入した項目を取得できること', async () => {
-    const actual = await repository.findById(dummyIncomeRecord.id)
+    const actual = await repository.findBy({
+      financialMonthId: dummyIncomeRecord.financialMonthId,
+      definitionId: dummyIncomeRecord.definitionId,
+    })
 
     expect(actual).toStrictEqual(dummyIncomeRecord)
   })
 
   test('項目を更新できること', async () => {
-    const actual = await repository.updateIncomeDefinitionValue(
-      dummyIncomeRecord.id,
+    const actual = await repository.updateIncomeRecordValue(
+      {
+        financialMonthId: dummyIncomeRecord.financialMonthId,
+        definitionId: dummyIncomeRecord.definitionId,
+      },
       200,
     )
 

--- a/backend/src/features/records/income/infrastructure/repositoryImpl.ts
+++ b/backend/src/features/records/income/infrastructure/repositoryImpl.ts
@@ -1,5 +1,5 @@
 import dayjs from '@/logic/dayjs'
-import { condition } from '@/logic/queryBuilder/conditionTree'
+import { condition, every } from '@/logic/queryBuilder/conditionTree'
 import { d1 } from '@/logic/queryBuilder/d1'
 
 import type { IncomeRecord } from '../domain/entity'
@@ -8,7 +8,6 @@ import { IncomeRecordRecord } from './entity'
 
 const makeIncomeRecord = (record: IncomeRecordRecord): IncomeRecord => {
   return {
-    id: record.id,
     userId: record.user_id,
     financialMonthId: record.financial_month_id,
     definitionId: record.definition_id,
@@ -20,7 +19,6 @@ const makeIncomeRecord = (record: IncomeRecordRecord): IncomeRecord => {
 
 const makeIncomeRecordRecord = (entity: IncomeRecord): IncomeRecordRecord => {
   return {
-    id: entity.id,
     user_id: entity.userId,
     financial_month_id: entity.financialMonthId,
     definition_id: entity.definitionId,
@@ -31,11 +29,15 @@ const makeIncomeRecordRecord = (entity: IncomeRecord): IncomeRecordRecord => {
 }
 
 const insertIncomeRecord = (db: D1Database): IncomeRecordRepository['insertIncomeRecord'] => async (record) => {
-  const stmt = `INSERT INTO income_records VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`
+  const stmt = `
+  INSERT INTO
+    income_records
+  VALUES
+    (?1, ?2, ?3, ?4, ?5, ?6)
+  `
   const recordData = makeIncomeRecordRecord(record)
 
   await db.prepare(stmt).bind(
-    recordData.id,
     recordData.user_id,
     recordData.financial_month_id,
     recordData.definition_id,
@@ -47,27 +49,45 @@ const insertIncomeRecord = (db: D1Database): IncomeRecordRepository['insertIncom
   return record
 }
 
-const findById = (db: D1Database): IncomeRecordRepository['findById'] => async (id) => {
+const findBy = (db: D1Database): IncomeRecordRepository['findBy'] => async ({ financialMonthId, definitionId }) => {
   const stmt = d1(db)
     .select(IncomeRecordRecord, 'income_records')
-    .where(condition('id', '==', id))
+    .where(every(
+      condition('financial_month_id', '==', financialMonthId),
+      condition('definition_id', '==', definitionId),
+    ))
     .build()
 
   const record = await stmt.first<IncomeRecordRecord>()
   return record ? makeIncomeRecord(record) : undefined
 }
 
-const updateIncomeDefinitionValue = (db: D1Database): IncomeRecordRepository['updateIncomeDefinitionValue'] => async (id, value) => {
-  const stmt = `UPDATE income_records SET value=?, updated_at=? WHERE id=?`
+const updateIncomeRecordValue = (db: D1Database): IncomeRecordRepository['updateIncomeRecordValue'] => async ({ financialMonthId, definitionId }, value) => {
+  const stmt = `
+  UPDATE income_records
+  SET
+    value = ?,
+    updated_at = ?
+  WHERE
+    financial_month_id = ?
+    AND definition_id = ?
+  `
 
   await db
     .prepare(stmt)
-    .bind(value, dayjs().valueOf(), id)
+    .bind(
+      value,
+      dayjs().valueOf(),
+      financialMonthId,
+      definitionId)
     .run()
 
   const updated = d1(db)
     .select(IncomeRecordRecord, 'income_records')
-    .where(condition('id', '==', id))
+    .where(every(
+      condition('financial_month_id', '==', financialMonthId),
+      condition('definition_id', '==', definitionId),
+    ))
     .build()
     .first<IncomeRecordRecord>()
     .then(record => record ? makeIncomeRecord(record) : undefined)
@@ -78,7 +98,7 @@ const updateIncomeDefinitionValue = (db: D1Database): IncomeRecordRepository['up
 export const useIncomeRecordRepositoryD1 = (db: D1Database): IncomeRecordRepository => {
   return {
     insertIncomeRecord: insertIncomeRecord(db),
-    findById: findById(db),
-    updateIncomeDefinitionValue: updateIncomeDefinitionValue(db),
+    findBy: findBy(db),
+    updateIncomeRecordValue: updateIncomeRecordValue(db),
   }
 }

--- a/backend/src/migrations/0009_fix_income_record_table.sql
+++ b/backend/src/migrations/0009_fix_income_record_table.sql
@@ -1,0 +1,21 @@
+-- Migration number: 0009 	 2025-04-30T06:01:04.821Z
+
+DROP TABLE IF EXISTS income_records;
+
+CREATE TABLE income_records (
+    user_id TEXT NOT NULL,
+
+    financial_month_id TEXT NOT NULL,
+    definition_id TEXT NOT NULL,
+
+    value INT NOT NULL,
+
+    updated_at INT NOT NULL,
+    updated_by TEXT NOT NULL,
+
+    FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE RESTRICT
+    FOREIGN KEY(financial_month_id) REFERENCES financial_months(id) ON DELETE RESTRICT
+    FOREIGN KEY(definition_id) REFERENCES income_definitions(id) ON DELETE RESTRICT
+
+    PRIMARY KEY(financial_month_id, definition_id)
+);


### PR DESCRIPTION
Fixes: #29

- **feat: #29 報酬実績エンティティからidを削除**
- **chore: #29 報酬実績テーブルを際生成するマイグレーションを構成**
