### PR TITLE
勤務日数機能の実装

### DIFF
--- a/backend/src/domains/workday/index.ts
+++ b/backend/src/domains/workday/index.ts
@@ -1,11 +1,13 @@
 import type dayjs from '@/logic/dayjs'
 
+import type { WorkdayValue } from './logic'
+
 /** 勤務日 */
 export type Workday = {
   userId: string
 
   financialMonthId: string
-  count: number
+  count: WorkdayValue
 
   updatedAt: dayjs.Dayjs
 }

--- a/backend/src/domains/workday/logic.ts
+++ b/backend/src/domains/workday/logic.ts
@@ -1,18 +1,25 @@
+import type { Result } from 'neverthrow'
+import { z } from 'zod'
+
 import dayjs from '@/logic/dayjs'
+import { ValidationError } from '@/logic/errors'
+import { parseSchema } from '@/logic/zod'
 
 import type { FinancialMonth } from '../financial_month'
 import type { Workday } from '.'
 
-// TODO: countの値域チェックを挟んでも良いのでは?
+export const WorkdayValueSchema = z.number().int().min(0).max(31).brand()
+export type WorkdayValue = z.infer<typeof WorkdayValueSchema>
+
 export const createWorkday = (props: {
   userId: string
   financialMonth: FinancialMonth
   count: number
-}): Workday => {
-  return {
-    userId: props.userId,
-    financialMonthId: props.financialMonth.id,
-    count: props.count,
-    updatedAt: dayjs(),
-  }
-}
+}): Result<Workday, ValidationError> =>
+  parseSchema(WorkdayValueSchema, props.count)
+    .map(count => ({
+      userId: props.userId,
+      financialMonthId: props.financialMonth.id,
+      count,
+      updatedAt: dayjs(),
+    })).mapErr(() => new ValidationError(''))

--- a/backend/src/features/financial_year/dao.ts
+++ b/backend/src/features/financial_year/dao.ts
@@ -70,7 +70,9 @@ const buildWorkdayInsertionQuery = (db: D1Database):
     userId: month.userId,
     financialMonth: month,
     count: 20, // NOTE: 本来はカレンダーライブラリ等を使うべき
-  })).map(makeWorkdayRecord)
+  }).unwrapOr(undefined))
+    .filter(workday => workday !== undefined)
+    .map(makeWorkdayRecord)
 
   const stmt = 'INSERT INTO workdays VALUES (?1,?2,?3,?4)'
   const base = db.prepare(stmt)

--- a/backend/src/features/income_record/dao.ts
+++ b/backend/src/features/income_record/dao.ts
@@ -93,3 +93,5 @@ export const updateIncomeRecordValue = (db: D1Database):
 
   return updatedRaw ? makeEntity(updatedRaw) : undefined
 }
+
+// TODO: 報酬実績のリセット (システム自動計算に戻す)

--- a/backend/src/features/workday/dao.test.ts
+++ b/backend/src/features/workday/dao.test.ts
@@ -1,12 +1,16 @@
 import { env } from 'cloudflare:test'
 
+import { createFinancialMonthData } from '@/domains/financial_month/logic'
 import { createFinancialYear } from '@/domains/financial_year/logic'
+import { createIncomeDefinition } from '@/domains/income_definition/logic'
 import type { User } from '@/domains/user'
 import { createUser } from '@/domains/user/logic'
 import type { WorkdayValue } from '@/domains/workday/logic'
 
 import { saveUser } from '../authorize/dao'
 import { insertFinancialYear } from '../financial_year/dao'
+import { insertIncomeDefinition } from '../income_definition/dao'
+import { updateIncomeRecordValue } from '../income_record/dao'
 import { findWorkdayByFinancialMonthId, updateWorkday } from './dao'
 
 describe('勤務日数エントリの操作', () => {
@@ -54,4 +58,230 @@ describe('勤務日数エントリの操作', () => {
   })
 })
 
-// TODO: 報酬実績が更新される(or ユーザ更新なら変更しない)ことを確認する
+describe('勤務日数更新時の報酬実績', () => {
+  const dummyUser: User = createUser({
+    name: 'testuser',
+    email: 'test@example.com',
+    auth0UserId: 'auth0_test_user',
+  })
+
+  const dummyFinancialYear = createFinancialYear({
+    userId: dummyUser.id,
+    year: 2025,
+  })._unsafeUnwrap()
+
+  const dummyAbsoluteIncomeDefinition = createIncomeDefinition({
+    userId: dummyUser.id,
+    name: '',
+    kind: 'absolute',
+    value: 500,
+    isTaxable: true,
+    from: createFinancialMonthData({
+      financialYear: 2025,
+      month: 4,
+    })._unsafeUnwrap(),
+    to: createFinancialMonthData({
+      financialYear: 2025,
+      month: 3,
+    })._unsafeUnwrap(),
+  })._unsafeUnwrap()
+
+  const dummyRelativeIncomeDefinition = createIncomeDefinition({
+    userId: dummyUser.id,
+    name: '',
+    kind: 'related_by_workday',
+    value: 300,
+    isTaxable: true,
+    from: createFinancialMonthData({
+      financialYear: 2025,
+      month: 4,
+    })._unsafeUnwrap(),
+    to: createFinancialMonthData({
+      financialYear: 2025,
+      month: 3,
+    })._unsafeUnwrap(),
+  })._unsafeUnwrap()
+
+  beforeAll(async () => {
+    await saveUser(env.D1)(dummyUser)
+    await insertFinancialYear(env.D1)(dummyFinancialYear)
+    await insertIncomeDefinition(env.D1)(dummyAbsoluteIncomeDefinition)
+    await insertIncomeDefinition(env.D1)(dummyRelativeIncomeDefinition)
+  })
+
+  test('24件の報酬実績が登録されていること', async () => {
+    const actual = await env.D1
+      .prepare('SELECT COUNT(*) count FROM income_records WHERE user_id=?')
+      .bind(dummyUser.id)
+      .first<{ count: number }>()
+
+    expect(actual?.count).toBe(24)
+  })
+
+  describe('4月度の勤務日数を変更した場合', () => {
+    beforeAll(async () => {
+      await updateWorkday(env.D1)({
+        userId: dummyUser.id,
+        financialMonthId: dummyFinancialYear.months[0].id,
+        count: 10 as WorkdayValue,
+      })
+    })
+
+    test('報酬実績レコードの数は変わらないこと', async () => {
+      const actual = await env.D1
+        .prepare('SELECT COUNT(*) count FROM income_records WHERE user_id=?')
+        .bind(dummyUser.id)
+        .first<{ count: number }>()
+
+      expect(actual?.count).toBe(24)
+    })
+
+    describe('4月分の報酬実績', () => {
+      let records: Record<string, unknown>[]
+
+      beforeAll(async () => {
+        const stmt = `SELECT * FROM income_records WHERE user_id=? AND financial_month_id=?`
+        const { results } = await env.D1
+          .prepare(stmt)
+          .bind(
+            dummyUser.id,
+            dummyFinancialYear.months[0].id,
+          )
+          .all()
+        records = results
+      })
+
+      test('2件登録されていること', () => {
+        expect(records).toHaveLength(2)
+      })
+
+      test('定数実績は更新されていないこと', () => {
+        const { id } = dummyAbsoluteIncomeDefinition
+        const absoluteRecord = records.find(record => record.definition_id === id)
+
+        expect(absoluteRecord?.value).toBe(500)
+      })
+
+      test('勤務日数に連動する実績は更新されていること', () => {
+        const { id } = dummyRelativeIncomeDefinition
+        const relativeRecord = records.find(record => record.definition_id === id)
+
+        expect(relativeRecord?.value).toBe(3000)
+      })
+    })
+
+    describe('5月分の報酬実績', () => {
+      let records: Record<string, unknown>[]
+
+      beforeAll(async () => {
+        const stmt = `SELECT * FROM income_records WHERE user_id=? AND financial_month_id=?`
+        const { results } = await env.D1
+          .prepare(stmt)
+          .bind(
+            dummyUser.id,
+            dummyFinancialYear.months[1].id,
+          )
+          .all()
+        records = results
+      })
+
+      test('2件登録されていること', () => {
+        expect(records).toHaveLength(2)
+      })
+
+      test('勤務日数に連動する実績は更新されていないこと', () => {
+        const { id } = dummyRelativeIncomeDefinition
+        const relativeRecord = records.find(record => record.definition_id === id)
+
+        expect(relativeRecord?.value).toBe(6000)
+      })
+    })
+  })
+
+  describe('ユーザが実績を修正してから勤務日数が変更された場合', () => {
+    beforeAll(async () => {
+      await updateIncomeRecordValue(env.D1)({
+        userId: dummyUser.id,
+        financialMonthId: dummyFinancialYear.months[0].id,
+        definitionId: dummyRelativeIncomeDefinition.id,
+        value: 1234,
+      })
+
+      await updateWorkday(env.D1)({
+        userId: dummyUser.id,
+        financialMonthId: dummyFinancialYear.months[0].id,
+        count: 10 as WorkdayValue,
+      })
+    })
+
+    test('報酬実績レコードの数は変わらないこと', async () => {
+      const actual = await env.D1
+        .prepare('SELECT COUNT(*) count FROM income_records WHERE user_id=?')
+        .bind(dummyUser.id)
+        .first<{ count: number }>()
+
+      expect(actual?.count).toBe(24)
+    })
+
+    describe('4月分の報酬実績', () => {
+      let records: Record<string, unknown>[]
+
+      beforeAll(async () => {
+        const stmt = `SELECT * FROM income_records WHERE user_id=? AND financial_month_id=?`
+        const { results } = await env.D1
+          .prepare(stmt)
+          .bind(
+            dummyUser.id,
+            dummyFinancialYear.months[0].id,
+          )
+          .all()
+        records = results
+      })
+
+      test('2件登録されていること', () => {
+        expect(records).toHaveLength(2)
+      })
+
+      test('定数実績は更新されていないこと', () => {
+        const { id } = dummyAbsoluteIncomeDefinition
+        const absoluteRecord = records.find(record => record.definition_id === id)
+
+        expect(absoluteRecord?.value).toBe(500)
+      })
+
+      test('勤務日数に連動する実績は更新されていないこと', () => {
+        const { id } = dummyRelativeIncomeDefinition
+        const relativeRecord = records.find(record => record.definition_id === id)
+
+        expect(relativeRecord?.value).toBe(1234)
+      })
+    })
+
+    describe('5月分の報酬実績', () => {
+      let records: Record<string, unknown>[]
+
+      beforeAll(async () => {
+        const stmt = `SELECT * FROM income_records WHERE user_id=? AND financial_month_id=?`
+        const { results } = await env.D1
+          .prepare(stmt)
+          .bind(
+            dummyUser.id,
+            dummyFinancialYear.months[1].id,
+          )
+          .all()
+        records = results
+      })
+
+      test('2件登録されていること', () => {
+        expect(records).toHaveLength(2)
+      })
+
+      test('勤務日数に連動する実績は更新されていないこと', () => {
+        const { id } = dummyRelativeIncomeDefinition
+        const relativeRecord = records.find(record => record.definition_id === id)
+
+        expect(relativeRecord?.value).toBe(6000)
+      })
+    })
+  })
+})

--- a/backend/src/features/workday/dao.test.ts
+++ b/backend/src/features/workday/dao.test.ts
@@ -3,6 +3,7 @@ import { env } from 'cloudflare:test'
 import { createFinancialYear } from '@/domains/financial_year/logic'
 import type { User } from '@/domains/user'
 import { createUser } from '@/domains/user/logic'
+import type { WorkdayValue } from '@/domains/workday/logic'
 
 import { saveUser } from '../authorize/dao'
 import { insertFinancialYear } from '../financial_year/dao'
@@ -37,7 +38,7 @@ describe('勤務日数エントリの操作', () => {
     await updateWorkday(env.D1)({
       userId: dummyUser.id,
       financialMonthId: dummyFinancialMonth.id,
-      count: 17,
+      count: 17 as WorkdayValue,
     })
 
     const actual
@@ -52,3 +53,5 @@ describe('勤務日数エントリの操作', () => {
     })
   })
 })
+
+// TODO: 報酬実績が更新される(or ユーザ更新なら変更しない)ことを確認する

--- a/backend/src/features/workday/dao.ts
+++ b/backend/src/features/workday/dao.ts
@@ -53,43 +53,64 @@ const buildWorkdayUpdateQuery = (db: D1Database):
 }
 
 const buildIncomeRecordUpdateQuery = (db: D1Database):
-(props: {}) => D1PreparedStatement => (props) => {
-  /*
-   なんもわからん
-
-   workdayに対応するfinancial_monthに関連するincome_recordsについて、
-   workdayとdefinitionをjoinしてvalueを再計算する クエリ
-
-   更新対象は workday.financial_month_id=? のレコードのみ
-
-   financial_monthはidを持つ、workdayはfinancial_month_idを持つ
-   income_definitinionはidを持つ、income_recordはfinancial_month_idとdefinition_idを持つ
-   */
+(props: {
+  updatedAt: dayjs.Dayjs
+  userId: User['id']
+  financialMonthId: FinancialMonth['id']
+}) => D1PreparedStatement => (props) => {
   const stmt = `
+  UPDATE income_records SET
+    value = CASE
+      WHEN d.kind = "related_by_workday" THEN d.value * w.count
+      ELSE d.value
+    END,
+    updated_at = ?
+  FROM
+    financial_months m
+    INNER JOIN workdays w ON m.id = w.financial_month_id
+    INNER JOIN income_definitions d ON d.disabled_at > m.started_at
+      AND d.enabled_at < m.ended_at
+  WHERE
+    income_records.financial_month_id = m.id
+    AND income_records.updated_by != "user"
+    AND d.kind == "related_by_workday"
+    AND income_records.financial_month_id = ?
+    AND income_records.user_id = ?
+    AND income_records.definition_id = d.id
   `
+
+  return db
+    .prepare(stmt)
+    .bind(
+      props.updatedAt.valueOf(),
+      props.financialMonthId,
+      props.userId,
+    )
 }
 
 export const updateWorkday = (db: D1Database):
-(props: Pick<Workday, 'userId' | 'financialMonthId' | 'count'>) => Promise<Workday | undefined> => async (props) => {
+(props: Pick<Workday, 'userId' | 'financialMonthId' | 'count'>) => Promise<Workday | undefined> => async ({
+  userId, financialMonthId, count,
+}) => {
   const updatedAt = dayjs()
 
   const queries: D1PreparedStatement[] = [
     buildWorkdayUpdateQuery(db)({
-      userId: props.userId,
-      count: props.count,
-      financialMonthId: props.financialMonthId,
+      userId,
+      count,
+      financialMonthId,
       updatedAt,
     }),
     buildIncomeRecordUpdateQuery(db)({
-      //
+      userId,
+      financialMonthId,
+      updatedAt,
     }),
     d1(db)
       .select(WorkdayRecord, 'workdays')
-      .where(condition('financial_month_id', '==', props.financialMonthId))
+      .where(condition('financial_month_id', '==', financialMonthId))
       .build(),
   ]
-
-  // TODO: 報酬実績値の更新
 
   const results = await db.batch<Workday>(queries)
   const updated = results.at(-1)?.results.at(0)

--- a/backend/src/features/workday/dao.ts
+++ b/backend/src/features/workday/dao.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import type { Workday } from '@/domains/workday'
+import type { WorkdayValue } from '@/domains/workday/logic'
 import dayjs from '@/logic/dayjs'
 import { condition } from '@/logic/queryBuilder/conditionTree'
 import { d1 } from '@/logic/queryBuilder/d1'
@@ -19,7 +20,7 @@ const makeEntity = ({
 }: WorkdayRecord): Workday => ({
   userId: user_id,
   financialMonthId: financial_month_id,
-  count,
+  count: count as WorkdayValue,
   updatedAt: dayjs(updated_at),
 })
 
@@ -42,6 +43,8 @@ export const updateWorkday = (db: D1Database):
       props.userId,
       props.financialMonthId,
     )
+
+  // TODO: 報酬実績値の更新
 
   const findQuery = d1(db)
     .select(WorkdayRecord, 'workdays')

--- a/backend/src/features/workday/dao.ts
+++ b/backend/src/features/workday/dao.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import type { FinancialMonth } from '@/domains/financial_month'
+import type { User } from '@/domains/user'
 import type { Workday } from '@/domains/workday'
 import type { WorkdayValue } from '@/domains/workday/logic'
 import dayjs from '@/logic/dayjs'
@@ -24,8 +26,13 @@ const makeEntity = ({
   updatedAt: dayjs(updated_at),
 })
 
-export const updateWorkday = (db: D1Database):
-(props: Pick<Workday, 'userId' | 'financialMonthId' | 'count'>) => Promise<Workday | undefined> => async (props) => {
+const buildWorkdayUpdateQuery = (db: D1Database):
+(props: {
+  count: WorkdayValue
+  updatedAt: dayjs.Dayjs
+  userId: User['id']
+  financialMonthId: FinancialMonth['id']
+}) => D1PreparedStatement => (props) => {
   const stmt = `
   UPDATE workdays SET
     count = ?1,
@@ -35,24 +42,57 @@ export const updateWorkday = (db: D1Database):
     AND financial_month_id = ?4
   `
 
-  const insertionQuery = db
+  return db
     .prepare(stmt)
     .bind(
       props.count,
-      dayjs().valueOf(),
+      props.updatedAt.valueOf(),
       props.userId,
       props.financialMonthId,
     )
+}
+
+const buildIncomeRecordUpdateQuery = (db: D1Database):
+(props: {}) => D1PreparedStatement => (props) => {
+  /*
+   なんもわからん
+
+   workdayに対応するfinancial_monthに関連するincome_recordsについて、
+   workdayとdefinitionをjoinしてvalueを再計算する クエリ
+
+   更新対象は workday.financial_month_id=? のレコードのみ
+
+   financial_monthはidを持つ、workdayはfinancial_month_idを持つ
+   income_definitinionはidを持つ、income_recordはfinancial_month_idとdefinition_idを持つ
+   */
+  const stmt = `
+  `
+}
+
+export const updateWorkday = (db: D1Database):
+(props: Pick<Workday, 'userId' | 'financialMonthId' | 'count'>) => Promise<Workday | undefined> => async (props) => {
+  const updatedAt = dayjs()
+
+  const queries: D1PreparedStatement[] = [
+    buildWorkdayUpdateQuery(db)({
+      userId: props.userId,
+      count: props.count,
+      financialMonthId: props.financialMonthId,
+      updatedAt,
+    }),
+    buildIncomeRecordUpdateQuery(db)({
+      //
+    }),
+    d1(db)
+      .select(WorkdayRecord, 'workdays')
+      .where(condition('financial_month_id', '==', props.financialMonthId))
+      .build(),
+  ]
 
   // TODO: 報酬実績値の更新
 
-  const findQuery = d1(db)
-    .select(WorkdayRecord, 'workdays')
-    .where(condition('financial_month_id', '==', props.financialMonthId))
-    .build()
-
-  const results = await db.batch<Workday>([insertionQuery, findQuery])
-  const updated = results.at(0)?.results.at(0)
+  const results = await db.batch<Workday>(queries)
+  const updated = results.at(-1)?.results.at(0)
 
   return updated
 }

--- a/backend/src/features/workday/route.ts
+++ b/backend/src/features/workday/route.ts
@@ -1,13 +1,20 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
+import { err, ok } from 'neverthrow'
+import { z } from 'zod'
 
 import { FinancialMonthDataSchema } from '@/domains/financial_month'
+import { WorkdayValueSchema } from '@/domains/workday/logic'
+import { EntityNotFoundError } from '@/logic/errors'
+import { fromSafePromise } from '@/logic/neverthrow'
 
 import { userAuthMiddleware } from '../authorize/middleware'
 import { getFinancialMonthByFinancialMonth } from '../financial_month/dao'
-import { findWorkdayByFinancialMonthId } from './dao'
+import { findWorkdayByFinancialMonthId, updateWorkday } from './dao'
 import type { GetWorkdayCommand } from './workflow/get'
 import { createGetWorkdayWorkflow } from './workflow/get'
+import type { PutWorkdayCommand } from './workflow/put'
+import { createPutWorkdayWorkflow } from './workflow/put'
 
 const app = new Hono<{ Bindings: Env }>()
   .use(userAuthMiddleware)
@@ -27,6 +34,47 @@ const app = new Hono<{ Bindings: Env }>()
       })
 
       const response = workflow(command)
+        .match(
+          entity => c.json(entity),
+          (error) => {
+            console.error(error)
+            return c.json({ error: 'not found' }, 404)
+          },
+        )
+
+      return response
+    },
+  )
+  .put(
+    '/:financialYear/:month',
+    zValidator('param', FinancialMonthDataSchema),
+    zValidator('json', z.object({ count: WorkdayValueSchema })),
+    async (c) => {
+      const command: PutWorkdayCommand = {
+        input: {
+          count: c.req.valid('json').count,
+          financialMonth: c.req.valid('param'),
+        },
+        state: { user: c.get('user') },
+      }
+
+      const workflow = createPutWorkdayWorkflow({
+        getFinancialMonthByFinancialMonth:
+        getFinancialMonthByFinancialMonth(c.env.D1),
+      })
+
+      const response = workflow(command)
+        .andThen(fromSafePromise(async (event) => {
+          const updated = await updateWorkday(c.env.D1)({
+            userId: event.user.id,
+            financialMonthId: event.financialMonth.id,
+            count: event.count,
+          })
+
+          return updated
+            ? ok(updated)
+            : err(new EntityNotFoundError({ id: event.financialMonth.id }))
+        }))
         .match(
           entity => c.json(entity),
           (error) => {

--- a/backend/src/features/workday/workflow/put.ts
+++ b/backend/src/features/workday/workflow/put.ts
@@ -1,0 +1,70 @@
+import type { ResultAsync } from 'neverthrow'
+import { err, ok } from 'neverthrow'
+
+import type { FinancialMonth, FinancialMonthData } from '@/domains/financial_month'
+import type { User } from '@/domains/user'
+import type { WorkdayValue } from '@/domains/workday/logic'
+import { EntityNotFoundError } from '@/logic/errors'
+import { fromSafePromise } from '@/logic/neverthrow'
+
+export interface PutWorkdayCommand {
+  input: {
+    financialMonth: FinancialMonthData
+    count: WorkdayValue
+  }
+  state: { user: User }
+}
+
+interface FinancialMonthQueried {
+  input: { count: WorkdayValue }
+  state: {
+    financialMonth: FinancialMonth
+    user: User
+  }
+}
+
+export interface FinancialMonthUpdateEvent {
+  user: User
+  financialMonth: FinancialMonth
+  count: WorkdayValue
+}
+
+const queryFinancialMonth = (effects: {
+  //
+  getFinancialMonthByFinancialMonth: (userId: string, financialMonth: FinancialMonthData) => Promise<FinancialMonth | undefined>
+}): (command: PutWorkdayCommand) => ResultAsync<FinancialMonthQueried, EntityNotFoundError> => fromSafePromise(async (command) => {
+  const financialMonth = command.input.financialMonth
+  const queried = await effects.getFinancialMonthByFinancialMonth(
+    command.state.user.id,
+    financialMonth,
+  )
+
+  if (queried === undefined) {
+    const imitatedEntityId = `${financialMonth.financialYear}-${financialMonth.month}`
+    return err(new EntityNotFoundError({ id: imitatedEntityId }))
+  }
+
+  return ok({
+    input: { count: command.input.count },
+    state: {
+      financialMonth: queried,
+      user: command.state.user,
+    },
+  })
+})
+
+const createPutEvent = (command: FinancialMonthQueried): FinancialMonthUpdateEvent => ({
+  user: command.state.user,
+  count: command.input.count,
+  financialMonth: command.state.financialMonth,
+})
+
+type PutWorkdayWorkflow = (command: PutWorkdayCommand) => ResultAsync<FinancialMonthUpdateEvent, EntityNotFoundError>
+
+export const createPutWorkdayWorkflow = (effects: {
+  //
+  getFinancialMonthByFinancialMonth: (userId: string, financialMonth: FinancialMonthData) => Promise<FinancialMonth | undefined>
+}): PutWorkdayWorkflow => command =>
+  ok(command)
+    .asyncAndThen(queryFinancialMonth(effects))
+    .map(createPutEvent)


### PR DESCRIPTION
Fixes: #36

勤務日数の取得・更新機能を実装しました。

- **feat: #36 勤務日数取得・更新ワークフロー、ルーティングの実装**
- **feat: #36 報酬実績挿入クエリの追加 (wip)**
- **feat: #36 勤務日数を修正した時に報酬実績が再計算される機能を追加**
