### PR TITLE
会計年度初期化時に報酬実績を触らないようにした

### DIFF
--- a/backend/src/features/financial_year/dao.test.ts
+++ b/backend/src/features/financial_year/dao.test.ts
@@ -1,5 +1,4 @@
 import { env } from 'cloudflare:test'
-import type { z } from 'zod'
 
 import { createFinancialMonthData } from '@/domains/financial_month/logic'
 import type { FinancialYearValue } from '@/domains/financial_year'
@@ -10,7 +9,6 @@ import { createUser } from '@/domains/user/logic'
 
 import { saveUser } from '../authorize/dao'
 import { insertIncomeDefinition } from '../income_definition/dao'
-import type { IncomeRecordRecord } from '../income_record/dao'
 import {
   getFinancialYear, insertFinancialYear, listFinancialYears,
 } from './dao'
@@ -44,7 +42,7 @@ describe('会計年度の生成', () => {
     expect(result?.count).toBe(12)
   })
 
-  test('報酬定義がないので実績は生成されないこと', async () => {
+  test('報酬実績は生成されないこと', async () => {
     const stmt = 'SELECT COUNT(*) count FROM income_records'
     const result = await env.D1.prepare(stmt).first<{ count: number }>()
     expect(result?.count).toBe(0)
@@ -169,36 +167,14 @@ describe('報酬定義が存在する場合', () => {
       year: 2024,
     })._unsafeUnwrap()
 
-    let records: z.infer<typeof IncomeRecordRecord>[]
-
     beforeAll(async () => {
       await insertFinancialYear(env.D1)(dummyFinancialYear)
-
-      const stmt = 'SELECT * FROM income_records WHERE user_id=?'
-      const { results } = await env.D1
-        .prepare(stmt)
-        .bind(dummyUser.id)
-        .all<z.infer<typeof IncomeRecordRecord>>()
-      records = results
     })
 
-    test('FY24-09 ~ FY25-09 までに定義された7件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition1.id)
-      expect(actual).toHaveLength(7)
-    })
-
-    test('FY24全体に定義された12件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition2.id)
-      expect(actual).toHaveLength(12)
-    })
-
-    test('FY25全体に定義された0件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition3.id)
-      expect(actual).toHaveLength(0)
-    })
-
-    test('実績の合計レコード数は19であること', () => {
-      expect(records).toHaveLength(19)
+    test('報酬実績は生成されないこと', async () => {
+      const stmt = 'SELECT COUNT(*) count FROM income_records'
+      const result = await env.D1.prepare(stmt).first<{ count: number }>()
+      expect(result?.count).toBe(0)
     })
   })
 
@@ -208,36 +184,14 @@ describe('報酬定義が存在する場合', () => {
       year: 2025,
     })._unsafeUnwrap()
 
-    let records: z.infer<typeof IncomeRecordRecord>[]
-
     beforeAll(async () => {
       await insertFinancialYear(env.D1)(dummyFinancialYear)
-
-      const stmt = 'SELECT * FROM income_records WHERE user_id=?'
-      const { results } = await env.D1
-        .prepare(stmt)
-        .bind(dummyUser.id)
-        .all<z.infer<typeof IncomeRecordRecord>>()
-      records = results
     })
 
-    test('FY24-09 ~ FY25-09 までに定義された6件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition1.id)
-      expect(actual).toHaveLength(6)
-    })
-
-    test('FY24全体に定義された0件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition2.id)
-      expect(actual).toHaveLength(0)
-    })
-
-    test('FY25全体に定義された12件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition3.id)
-      expect(actual).toHaveLength(12)
-    })
-
-    test('実績の合計レコード数は18であること', () => {
-      expect(records).toHaveLength(18)
+    test('報酬実績は生成されないこと', async () => {
+      const stmt = 'SELECT COUNT(*) count FROM income_records'
+      const result = await env.D1.prepare(stmt).first<{ count: number }>()
+      expect(result?.count).toBe(0)
     })
   })
 
@@ -252,37 +206,15 @@ describe('報酬定義が存在する場合', () => {
       year: 2025,
     })._unsafeUnwrap()
 
-    let records: z.infer<typeof IncomeRecordRecord>[]
-
     beforeAll(async () => {
       await insertFinancialYear(env.D1)(dummyFinancialYear24)
       await insertFinancialYear(env.D1)(dummyFinancialYear25)
-
-      const stmt = 'SELECT * FROM income_records WHERE user_id=?'
-      const { results } = await env.D1
-        .prepare(stmt)
-        .bind(dummyUser.id)
-        .all<z.infer<typeof IncomeRecordRecord>>()
-      records = results
     })
 
-    test('FY24-09 ~ FY25-09 までに定義された13件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition1.id)
-      expect(actual).toHaveLength(13)
-    })
-
-    test('FY24全体に定義された12件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition2.id)
-      expect(actual).toHaveLength(12)
-    })
-
-    test('FY25全体に定義された12件の実績が記録されること', () => {
-      const actual = records.filter(record => record.definition_id === dummyDefinition3.id)
-      expect(actual).toHaveLength(12)
-    })
-
-    test('実績の合計レコード数は37であること', () => {
-      expect(records).toHaveLength(37)
+    test('報酬実績は生成されないこと', async () => {
+      const stmt = 'SELECT COUNT(*) count FROM income_records'
+      const result = await env.D1.prepare(stmt).first<{ count: number }>()
+      expect(result?.count).toBe(0)
     })
   })
 })

--- a/backend/src/features/financial_year/dao.ts
+++ b/backend/src/features/financial_year/dao.ts
@@ -4,7 +4,6 @@ import type { FinancialYear, FinancialYearValue } from '@/domains/financial_year
 import type { User } from '@/domains/user'
 import type { Workday } from '@/domains/workday'
 import { createWorkday } from '@/domains/workday/logic'
-import dayjs from '@/logic/dayjs'
 import { condition, every } from '@/logic/queryBuilder/conditionTree'
 import { d1 } from '@/logic/queryBuilder/d1'
 
@@ -85,51 +84,12 @@ const buildWorkdayInsertionQuery = (db: D1Database):
   ))
 }
 
-const buildIncomeRecordInsertionQuery = (db: D1Database):
-(entity: FinancialYear) => D1PreparedStatement => (entity) => {
-  const stmt = `
-  INSERT INTO
-    income_records
-  SELECT
-    m.user_id,
-    m.id AS financial_month_id,
-    d.id AS definition_id,
-    CASE
-      WHEN d.kind = "related_by_workday" THEN d.value * w.count
-      ELSE d.value
-    END value,
-    ? updated_at,
-    "system" updated_by
-  FROM
-    financial_months m
-    INNER JOIN workdays w ON m.id = w.financial_month_id
-    INNER JOIN income_definitions d ON d.disabled_at > m.started_at
-    AND d.enabled_at < m.ended_at
-  WHERE
-    m.financial_year = ? ON CONFLICT (financial_month_id, definition_id) DO
-  UPDATE
-  SET
-    updated_at = excluded.updated_at,
-    value = excluded.value
-  WHERE
-    excluded.updated_by != "user"
-  `
-
-  return db
-    .prepare(stmt)
-    .bind(
-      dayjs().valueOf(),
-      entity.year,
-    )
-}
-
 export const insertFinancialYear = (db: D1Database):
 (item: FinancialYear) => Promise<FinancialYear> =>
   async (entity) => {
     const queries: D1PreparedStatement[] = [
       ...buildFinancialMonthInsertionQuery(db)(entity),
       ...buildWorkdayInsertionQuery(db)(entity),
-      buildIncomeRecordInsertionQuery(db)(entity),
     ]
 
     await db.batch(queries)


### PR DESCRIPTION
Fixes: #42

- **test: テストケース修正**
- **fix: #42 会計年度初期化時に報酬実績エンティティを挿入しないようにした**
