### PR TITLE
デフォルトの月額表を得るロジックを追加

### DIFF
--- a/backend/src/domains/standard_income/logic/default.test.ts
+++ b/backend/src/domains/standard_income/logic/default.test.ts
@@ -1,0 +1,12 @@
+import { Ok } from 'neverthrow'
+
+import dayjs from '@/logic/dayjs'
+
+import { getDefaultStandardIncomeGrades } from './defaults'
+
+describe('デフォルト値の取得', () => {
+  test('取得できること', () => {
+    const actual = getDefaultStandardIncomeGrades(dayjs())
+    expect(actual).toBeInstanceOf(Ok)
+  })
+})

--- a/backend/src/domains/standard_income/logic/defaults.ts
+++ b/backend/src/domains/standard_income/logic/defaults.ts
@@ -1,0 +1,77 @@
+import { Result } from 'neverthrow'
+
+import type dayjs from '@/logic/dayjs'
+
+import type { StandardIncomeGrade } from '..'
+import { createStandardIncomeGrade } from '.'
+
+/**
+ * 令和7年標準報酬月額等級
+ * @see https://www.kyoukaikenpo.or.jp/~/media/Files/shared/hokenryouritu/r7/ippan/20nagano.pdf
+ */
+const reiwa7StandardIncomeGrades = [
+  { threshold: 0, standardIncome: 58000 },
+  { threshold: 68000, standardIncome: 63000 },
+  { threshold: 78000, standardIncome: 73000 },
+  { threshold: 88000, standardIncome: 83000 },
+  { threshold: 98000, standardIncome: 93000 },
+  { threshold: 104000, standardIncome: 101000 },
+  { threshold: 110000, standardIncome: 107000 },
+  { threshold: 118000, standardIncome: 114000 },
+  { threshold: 126000, standardIncome: 122000 },
+  { threshold: 134000, standardIncome: 130000 },
+  { threshold: 142000, standardIncome: 138000 },
+  { threshold: 150000, standardIncome: 146000 },
+  { threshold: 160000, standardIncome: 155000 },
+  { threshold: 170000, standardIncome: 165000 },
+  { threshold: 180000, standardIncome: 175000 },
+  { threshold: 190000, standardIncome: 185000 },
+  { threshold: 200000, standardIncome: 195000 },
+  { threshold: 220000, standardIncome: 210000 },
+  { threshold: 240000, standardIncome: 230000 },
+  { threshold: 260000, standardIncome: 250000 },
+  { threshold: 280000, standardIncome: 270000 },
+  { threshold: 300000, standardIncome: 290000 },
+  { threshold: 320000, standardIncome: 310000 },
+  { threshold: 340000, standardIncome: 330000 },
+  { threshold: 360000, standardIncome: 350000 },
+  { threshold: 380000, standardIncome: 370000 },
+  { threshold: 410000, standardIncome: 395000 },
+  { threshold: 440000, standardIncome: 425000 },
+  { threshold: 470000, standardIncome: 455000 },
+  { threshold: 500000, standardIncome: 485000 },
+  { threshold: 530000, standardIncome: 515000 },
+  { threshold: 560000, standardIncome: 545000 },
+  { threshold: 590000, standardIncome: 575000 },
+  { threshold: 620000, standardIncome: 605000 },
+  { threshold: 650000, standardIncome: 635000 },
+  { threshold: 680000, standardIncome: 665000 },
+  { threshold: 710000, standardIncome: 695000 },
+  { threshold: 750000, standardIncome: 730000 },
+  { threshold: 790000, standardIncome: 770000 },
+  { threshold: 830000, standardIncome: 810000 },
+  { threshold: 880000, standardIncome: 855000 },
+  { threshold: 930000, standardIncome: 905000 },
+  { threshold: 980000, standardIncome: 955000 },
+  { threshold: 1030000, standardIncome: 1005000 },
+  { threshold: 1090000, standardIncome: 1055000 },
+  { threshold: 1150000, standardIncome: 1115000 },
+  { threshold: 1210000, standardIncome: 1175000 },
+  { threshold: 1270000, standardIncome: 1235000 },
+  { threshold: 1330000, standardIncome: 1295000 },
+  { threshold: 1390000, standardIncome: 1355000 },
+]
+
+/**
+ * 与えられた時刻で有効な標準報酬月額表を得る
+ * @param _ 日時
+ * @returns 日時に基づく標準報酬月額等級
+ */
+export const getDefaultStandardIncomeGrades = (
+  _: dayjs.Dayjs,
+): Result<StandardIncomeGrade[], Error> => {
+  // NOTE: 日付によって返すべきテーブルを変えるなどする。現時点では令和7年版のもののみ採用
+  return Result.combine(
+    reiwa7StandardIncomeGrades.map(createStandardIncomeGrade),
+  )
+}

--- a/backend/src/domains/standard_income/logic/index.test.ts
+++ b/backend/src/domains/standard_income/logic/index.test.ts
@@ -1,10 +1,10 @@
 import { Ok } from 'neverthrow'
 
+import type { User } from '@/domains/user'
+import { createUser } from '@/domains/user/logic'
 import { ValidationError } from '@/logic/errors'
 
-import type { User } from '../user'
-import { createUser } from '../user/logic'
-import { createStandardIncomeTable } from './logic'
+import { createStandardIncomeTable } from '.'
 
 const dummyUser: User = createUser({
   name: 'testuser',

--- a/backend/src/domains/standard_income/logic/index.ts
+++ b/backend/src/domains/standard_income/logic/index.ts
@@ -5,8 +5,8 @@ import { ulid } from 'ulid'
 import { ValidationError } from '@/logic/errors'
 import { parseSchema } from '@/logic/zod'
 
-import type { StandardIncomeGrade, StandardIncomeTable } from '.'
-import { StandardIncomeGradeSchema, StandardIncomeTableSchema } from '.'
+import type { StandardIncomeGrade, StandardIncomeTable } from '..'
+import { StandardIncomeGradeSchema, StandardIncomeTableSchema } from '..'
 
 export const createStandardIncomeGrade = (props: {
   threshold: number

--- a/backend/src/features/standard_income/route.test.ts
+++ b/backend/src/features/standard_income/route.test.ts
@@ -237,4 +237,13 @@ describe('標準報酬月額表API', () => {
       })
     })
   })
+
+  test('デフォルトの月額表を取得できること', async () => {
+    const result = await client.default.$get(
+      { param: { id: testTable.id } },
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+
+    expect(result.ok).toBeTruthy()
+  })
 })

--- a/backend/src/features/standard_income/route.ts
+++ b/backend/src/features/standard_income/route.ts
@@ -4,6 +4,8 @@ import { err, ok } from 'neverthrow'
 import { z } from 'zod'
 
 import { createStandardIncomeTable } from '@/domains/standard_income/logic'
+import { getDefaultStandardIncomeGrades } from '@/domains/standard_income/logic/defaults'
+import dayjs from '@/logic/dayjs'
 import { EntityNotFoundError } from '@/logic/errors'
 import { fromSafePromise } from '@/logic/neverthrow'
 
@@ -41,6 +43,16 @@ const app = new Hono<{ Bindings: Env }>()
       return c.json(entities)
     },
   )
+
+  // 現在時刻に基づく標準報酬月額表を取得
+  .get('/default', (c) => {
+    const result = getDefaultStandardIncomeGrades(dayjs())
+    if (result.isErr()) {
+      return c.json({ error: 'internal server error' }, 500)
+    }
+
+    return c.json(result.value)
+  })
 
   // 単一の標準報酬月額表を取得
   .get('/:id', zValidator('param', z.object({ id: z.string() })), async (c) => {


### PR DESCRIPTION
Fixes: #79

- **feat: #79 デフォルトの標準報酬月額テーブルを追加**
- **feat: #79 デフォルト報酬定義表を得るエンドポイントを追加**
