### PR TITLE
エンティティdaoの定義を追加した

### DIFF
--- a/backend/src/dao/actual/index.ts
+++ b/backend/src/dao/actual/index.ts
@@ -1,0 +1,9 @@
+import type { Actual } from '@/domains/actual'
+
+export interface ActualDao {
+  /** 月度と定義を指定して実績を挿入または更新する */
+  saveActual(actual: Actual): Promise<Actual | undefined>
+
+  /** 月度と定義を指定して実績を削除する */
+  deleteActual(actual: Actual): Promise<Actual | undefined>
+}

--- a/backend/src/dao/actual/schema.ts
+++ b/backend/src/dao/actual/schema.ts
@@ -1,39 +1,29 @@
 import { z } from 'zod'
 
 import type { Actual } from '@/domains/actual'
-import type { MonthlyContext } from '@/domains/monthly_context'
-import { EntityIdSchema, MoneySchema } from '@/domains/schema'
-
-import type { MonthlyContextRecord } from '../monthly_context/schema'
+import { EntityIdSchema, MoneySchema, TimestampSchema } from '@/domains/schema'
 
 export const ActualRecordSchema = z.object({
-  id: EntityIdSchema('actual'),
   user_id: EntityIdSchema('user'),
-  definition_id: EntityIdSchema('definition'),
   monthly_context_id: EntityIdSchema('monthly_context'),
+  definition_id: EntityIdSchema('definition'),
   value: MoneySchema,
+  updated_at: TimestampSchema,
 })
 export type ActualRecord = z.infer<typeof ActualRecordSchema>
 
-export const makeActualEntity = (
-  actual: ActualRecord,
-  context: MonthlyContextRecord,
-): Actual => ({
-  id: actual.id,
+export const makeActualEntity = (actual: ActualRecord): Actual => ({
   userId: actual.user_id,
+  monthlyContextId: actual.monthly_context_id,
   definitionId: actual.definition_id,
-  financialYear: context.financial_year,
-  month: context.month,
   value: actual.value,
+  updatedAt: actual.updated_at,
 })
 
-export const makeActualRecord = (
-  actual: Actual,
-  context: MonthlyContext,
-): ActualRecord => ({
-  id: actual.id,
+export const makeActualRecord = (actual: Actual): ActualRecord => ({
   user_id: actual.userId,
   definition_id: actual.definitionId,
-  monthly_context_id: context.id,
+  monthly_context_id: actual.monthlyContextId,
   value: actual.value,
+  updated_at: actual.updatedAt,
 })

--- a/backend/src/dao/definition/index.ts
+++ b/backend/src/dao/definition/index.ts
@@ -1,0 +1,52 @@
+import type { Definition } from '@/domains/definition'
+import type { Timestamp } from '@/domains/schema'
+import type { User } from '@/domains/user'
+
+export interface DefinitionDao {
+  /** 新しい定義を挿入する */
+  insertDefinition(definition: Definition): Promise<Definition>
+
+  /** IDを指定して定義を取得する */
+  getDefinitionById(props: {
+    id: Definition['id']
+    userId: User['id']
+  }): Promise<Definition | undefined>
+
+  /** 定義の一覧を取得する */
+  listDefinitions(props: {
+    userId: User['id']
+    sortBy: 'enabledAt' | 'updatedAt'
+    limit: number
+    offset?: number
+  }): Promise<Definition[]>
+
+  /** その日時を期間に含む定義の一覧を取得する */
+  findDefinitionsByDate(props: {
+    userId: User['id']
+    at: Timestamp
+  }): Promise<Definition[]>
+
+  /** 定義名を更新する */
+  updateDefinitionName(props: {
+    id: Definition['id']
+    userId: User['id']
+    name: string
+  }): Promise<Definition | undefined>
+
+  /** 定義の有効期間を更新する */
+  updateDefinitionPeriod(props: {
+    id: Definition['id']
+    userId: User['id']
+    enabledAt: Definition['enabledAt']
+    disabledAt: Definition['disabledAt']
+  }): Promise<Definition | undefined>
+
+  /**
+   * 定義を削除する
+   * @warning 紐付いている実績が存在する場合は削除に失敗します。
+   */
+  deleteDefinition(props: {
+    id: Definition['id']
+    userId: User['id']
+  }): Promise<Definition | undefined>
+}

--- a/backend/src/dao/financial_year/schema.ts
+++ b/backend/src/dao/financial_year/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+import type { FinancialYear } from '@/domains/financial_year'
+import { FinancialYearValueSchema } from '@/domains/financial_year'
+import { EntityIdSchema } from '@/domains/schema'
+
+export const FinancialYearRecordSchema = z.object({
+  id: EntityIdSchema('financial_year'),
+  user_id: EntityIdSchema('user'),
+  year: FinancialYearValueSchema,
+  standard_income_table_id: EntityIdSchema('standard_income_table'),
+})
+export type FinancialYearRecord = z.infer<typeof FinancialYearRecordSchema>
+
+export const makeFinancialYearRecord = (
+  entity: FinancialYear,
+): FinancialYearRecord => ({
+  id: entity.id,
+  user_id: entity.userId,
+  year: entity.year,
+  standard_income_table_id: entity.standardIncomeTable.id,
+})

--- a/backend/src/dao/monthly_context/schema.ts
+++ b/backend/src/dao/monthly_context/schema.ts
@@ -2,19 +2,16 @@ import { z } from 'zod'
 
 import type { Actual } from '@/domains/actual'
 import type { Definition } from '@/domains/definition'
-import { FinancialYearValueSchema } from '@/domains/financial_year'
 import type { MonthlyContext } from '@/domains/monthly_context'
 import { MonthsSchema, WorkdayValueSchema } from '@/domains/monthly_context'
 import { EntityIdSchema } from '@/domains/schema'
-import type { StandardIncomeTable } from '@/domains/standard_income'
 
 export const MonthlyContextRecordSchema = z.object({
   id: EntityIdSchema('monthly_context'),
   user_id: EntityIdSchema('user'),
-  financial_year: FinancialYearValueSchema,
+  financial_year_id: EntityIdSchema('financial_year'),
   month: MonthsSchema,
   workday: WorkdayValueSchema,
-  standard_income_table_id: EntityIdSchema('standard_income_table'),
 })
 export type MonthlyContextRecord = z.infer<typeof MonthlyContextRecordSchema>
 
@@ -23,24 +20,21 @@ export const makeMonthlyContextRecord = (
 ): MonthlyContextRecord => ({
   id: entity.id,
   user_id: entity.userId,
-  financial_year: entity.financialYear,
+  financial_year_id: entity.financialYearId,
   month: entity.month,
   workday: entity.workday,
-  standard_income_table_id: entity.standardIncomeTable.id,
 })
 
 export const makeMonthlyContextEntity = (
   record: MonthlyContextRecord,
   definitions: Definition[],
   actuals: Actual[],
-  standardIncomeTable: StandardIncomeTable,
 ): MonthlyContext => ({
   id: record.id,
   month: record.month,
   workday: record.workday,
+  financialYearId: record.financial_year_id,
   userId: record.user_id,
   definitions,
   actuals,
-  financialYear: record.financial_year,
-  standardIncomeTable,
 })

--- a/backend/src/dao/standard_income/d1.ts
+++ b/backend/src/dao/standard_income/d1.ts
@@ -150,7 +150,7 @@ export const listStandardIncomeTables =
 
 /** IDを指定して標準報酬月額表を取得する */
 export const getStandardIncomeTable =
-  (db: D1Database): StandardIncomeDao['getStandardIncomeTable'] =>
+  (db: D1Database): StandardIncomeDao['getStandardIncomeTableById'] =>
   async (props) => {
     const tableFetchQuery = d1(db)
       .select(StandardIncomeTableRecord, 'standard_income_tables')

--- a/backend/src/dao/standard_income/index.ts
+++ b/backend/src/dao/standard_income/index.ts
@@ -7,17 +7,17 @@ import type { User } from '@/domains/user'
 
 export interface StandardIncomeDao {
   /** IDを指定して標準報酬月額表を取得する */
-  getStandardIncomeTable(props: {
+  getStandardIncomeTableById(props: {
     userId: User['id']
     id: StandardIncomeTable['id']
   }): Promise<StandardIncomeTable | undefined>
 
-  /** 新しい標準報酬月額表を追加 */
+  /** 新しい標準報酬月額表を挿入する */
   insertStandardIncomeTable(
     item: StandardIncomeTable,
   ): Promise<StandardIncomeTable>
 
-  /** 登録されている標準報酬月額表の一覧を得る */
+  /** 標準報酬月額表の一覧を取得する */
   listStandardIncomeTables(props: {
     userId: User['id']
     order?: 'asc' | 'desc'

--- a/backend/src/domains/actual/index.ts
+++ b/backend/src/domains/actual/index.ts
@@ -1,16 +1,13 @@
 import { z } from 'zod'
 
-import { FinancialYearValueSchema } from '../financial_year'
-import { MonthsSchema } from '../monthly_context'
-import { EntityIdSchema, MoneySchema } from '../schema'
+import { EntityIdSchema, MoneySchema, TimestampSchema } from '../schema'
 
 export const ActualSchema = z.object({
-  id: EntityIdSchema('actual'),
   userId: EntityIdSchema('user'),
-  financialYear: FinancialYearValueSchema,
-  month: MonthsSchema,
+  monthlyContextId: EntityIdSchema('monthly_context'),
   definitionId: EntityIdSchema('definition'),
   value: MoneySchema,
+  updatedAt: TimestampSchema,
 })
 
 export type Actual = z.infer<typeof ActualSchema>

--- a/backend/src/domains/actual/logic.ts
+++ b/backend/src/domains/actual/logic.ts
@@ -1,26 +1,27 @@
 import type { Result } from 'neverthrow'
 import { ulid } from 'ulid'
 
+import dayjs from '@/logic/dayjs'
 import type { ValidationError } from '@/logic/errors'
 import { parseSchema } from '@/logic/zod'
 
 import type { Definition } from '../definition'
+import type { MonthlyContext } from '../monthly_context'
 import type { User } from '../user'
 import type { Actual } from '.'
 import { ActualSchema } from '.'
 
 export const createActual = (props: {
   userId: User['id']
-  financialYear: number
-  month: number
+  monthlyContextId: MonthlyContext['id']
   definitionId: Definition['id']
   value: number
 }): Result<Actual, ValidationError> =>
   parseSchema(ActualSchema, {
     id: ulid(),
     userId: props.userId,
-    financialYear: props.financialYear,
-    month: props.month,
+    monthlyContextId: props.monthlyContextId,
     definitionId: props.definitionId,
     value: props.value,
+    updatedAt: dayjs().timestamp(),
   })

--- a/backend/src/domains/definition/logic.ts
+++ b/backend/src/domains/definition/logic.ts
@@ -64,9 +64,9 @@ export const createDefinition = (
         userId: props.userId,
         name: props.name,
         value: props.value,
-        enabledAt: start.valueOf(),
-        disabledAt: end.valueOf(),
-        updatedAt: dayjs().valueOf(),
+        enabledAt: start.timestamp(),
+        disabledAt: end.timestamp(),
+        updatedAt: dayjs().timestamp(),
       }
 
       if (props.type === 'income') {

--- a/backend/src/domains/financial_year/index.ts
+++ b/backend/src/domains/financial_year/index.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
-import type { MonthlyContext } from '../monthly_context'
+import { MonthsSchema } from '../monthly_context'
+import { EntityIdSchema } from '../schema'
+import { StandardIncomeTableSchema } from '../standard_income'
 
 export const FinancialYearValueSchema = z
   .number()
@@ -11,8 +13,20 @@ export const FinancialYearValueSchema = z
 
 export type FinancialYearValue = z.infer<typeof FinancialYearValueSchema>
 
+export const FinancialYearSchema = z.object({
+  id: EntityIdSchema('financial_year'),
+  userId: EntityIdSchema('user'),
+  year: FinancialYearValueSchema,
+  months: z
+    .array(
+      z.object({
+        id: EntityIdSchema('monthly_context'),
+        month: MonthsSchema,
+      }),
+    )
+    .length(12),
+  standardIncomeTable: StandardIncomeTableSchema,
+})
+
 /** 会計年度 */
-export interface FinancialYear {
-  year: FinancialYearValue
-  months: MonthlyContext[]
-}
+export type FinancialYear = z.infer<typeof FinancialYearSchema>

--- a/backend/src/domains/financial_year/logic.ts
+++ b/backend/src/domains/financial_year/logic.ts
@@ -1,39 +1,24 @@
-import { Result } from 'neverthrow'
+import type { Result } from 'neverthrow'
+import { ulid } from 'ulid'
 
-import { ValidationError } from '@/logic/errors'
+import type { ValidationError } from '@/logic/errors'
 import { parseSchema } from '@/logic/zod'
 
 import { Months } from '../monthly_context'
-import { createMonthlyContext } from '../monthly_context/logic'
 import type { StandardIncomeTable } from '../standard_income'
 import type { User } from '../user'
 import type { FinancialYear } from '.'
-import { FinancialYearValueSchema } from '.'
-
-export const createFinancialYearValue = (value: number) =>
-  parseSchema(FinancialYearValueSchema, value).mapErr(
-    (error) => new ValidationError(error.message),
-  )
+import { FinancialYearSchema } from '.'
 
 export const createFinancialYear = (props: {
   userId: User['id']
-  financialYear: number
-  standardIncomeTableId: StandardIncomeTable['id']
-}): Result<FinancialYear, ValidationError> => {
-  const { userId, financialYear, standardIncomeTableId } = props
-
-  const results = Months.map((month) =>
-    createMonthlyContext({
-      userId,
-      financialYear,
-      month,
-      workday: 20, // TODO: 本来は各月の祝日を参照するべき
-      standardIncomeTableId,
-    }),
-  )
-
-  return Result.combine(results).map((months) => ({
-    year: months[0].financialYear,
-    months,
-  }))
-}
+  year: number
+  standardIncomeTable: StandardIncomeTable
+}): Result<FinancialYear, ValidationError> =>
+  parseSchema(FinancialYearSchema, {
+    id: ulid(),
+    userId: props.userId,
+    year: props.year,
+    months: Months.map((month) => ({ id: ulid(), month })),
+    standardIncomeTable: props.standardIncomeTable,
+  })

--- a/backend/src/domains/monthly_context/index.ts
+++ b/backend/src/domains/monthly_context/index.ts
@@ -4,7 +4,6 @@ import { ActualSchema } from '../actual'
 import { DefinitionSchema } from '../definition'
 import { FinancialYearValueSchema } from '../financial_year'
 import { EntityIdSchema } from '../schema'
-import { StandardIncomeTableSchema } from '../standard_income'
 
 export const WorkdayValueSchema = z.number().int().min(0).max(31).brand()
 export type WorkdayValue = z.infer<typeof WorkdayValueSchema>
@@ -29,7 +28,6 @@ export const MonthlyContextSchema = z
     workday: WorkdayValueSchema,
     definitions: z.array(DefinitionSchema),
     actuals: z.array(ActualSchema),
-    standardIncomeTable: StandardIncomeTableSchema,
   })
   .merge(FinancialMonthInfoSchema)
 

--- a/backend/src/domains/monthly_context/index.ts
+++ b/backend/src/domains/monthly_context/index.ts
@@ -21,15 +21,15 @@ export const FinancialMonthInfoSchema = z.object({
 /** 会計月度情報 */
 export type FinancialMonthInfo = z.infer<typeof FinancialMonthInfoSchema>
 
-export const MonthlyContextSchema = z
-  .object({
-    id: EntityIdSchema('monthly_context'),
-    userId: EntityIdSchema('user'),
-    workday: WorkdayValueSchema,
-    definitions: z.array(DefinitionSchema),
-    actuals: z.array(ActualSchema),
-  })
-  .merge(FinancialMonthInfoSchema)
+export const MonthlyContextSchema = z.object({
+  id: EntityIdSchema('monthly_context'),
+  userId: EntityIdSchema('user'),
+  financialYearId: EntityIdSchema('financial_year'),
+  month: MonthsSchema,
+  workday: WorkdayValueSchema,
+  definitions: z.array(DefinitionSchema),
+  actuals: z.array(ActualSchema),
+})
 
 /** 会計月度コンテキスト */
 export type MonthlyContext = z.infer<typeof MonthlyContextSchema>

--- a/backend/src/domains/monthly_context/index.ts
+++ b/backend/src/domains/monthly_context/index.ts
@@ -11,7 +11,7 @@ export type WorkdayValue = z.infer<typeof WorkdayValueSchema>
 export const MonthsSchema = z.number().int().min(1).max(12).brand()
 export type Months = z.infer<typeof MonthsSchema>
 
-export const Months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
+export const Months = [4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3] as const
 
 export const FinancialMonthInfoSchema = z.object({
   financialYear: FinancialYearValueSchema,

--- a/backend/src/domains/monthly_context/logic.ts
+++ b/backend/src/domains/monthly_context/logic.ts
@@ -7,7 +7,6 @@ import { parseSchema } from '@/logic/zod'
 
 import type { Actual } from '../actual'
 import type { Definition } from '../definition'
-import type { StandardIncomeTable } from '../standard_income'
 import type { FinancialMonthInfo, MonthlyContext } from '.'
 import { FinancialMonthInfoSchema, MonthlyContextSchema } from '.'
 
@@ -28,7 +27,6 @@ export const createMonthlyContext = (props: {
   workday: number
   definitions: Definition[]
   actuals: Actual[]
-  standardIncomeTable: StandardIncomeTable
 }): Result<MonthlyContext, ValidationError> =>
   parseSchema(MonthlyContextSchema, {
     ...props,

--- a/backend/src/logic/dayjs.ts
+++ b/backend/src/logic/dayjs.ts
@@ -13,7 +13,7 @@ import type { Timestamp } from '@/domains/schema'
 
 declare module 'dayjs' {
   interface Dayjs {
-    toTimestamp(): Timestamp
+    timestamp(): Timestamp
   }
 }
 
@@ -23,7 +23,7 @@ dayjs.extend(isLeapYear)
 dayjs.extend(relativeTime)
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-dayjs.prototype.toTimestamp = function () {
+dayjs.prototype.timestamp = function () {
   return (this as dayjs.Dayjs).valueOf() as Timestamp
 }
 

--- a/backend/src/migrations/0001_create_tables.sql
+++ b/backend/src/migrations/0001_create_tables.sql
@@ -6,21 +6,29 @@ CREATE TABLE users (
     email TEXT NOT NULL DEFAULT ''
 );
 
-CREATE TABLE financial_month_contexts (
+CREATE TABLE financial_years (
     id TEXT PRIMARY KEY NOT NULL,
     user_id TEXT NOT NULL,
-    financial_year INT NOT NULL,
-    month INT NOT NULL,
-    started_at INT NOT NULL,
-    ended_at INT NOT NULL,
-    workday INT NOT NULL DEFAULT 20,
+    year INT NOT NULL,
     standard_income_table_id TEXT NOT NULL,
-    UNIQUE (user_id, financial_year, month),
+    UNIQUE (user_id, financial_year),
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
     FOREIGN KEY (standard_income_table_id) REFERENCES standard_income_tables (id) ON DELETE RESTRICT
 );
 
-CREATE TABLE income_definitions (
+CREATE TABLE monthly_contexts (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL,
+    financial_year_id TEXT NOT NULL,
+    month INT NOT NULL,
+    started_at INT NOT NULL,
+    ended_at INT NOT NULL,
+    workday INT NOT NULL DEFAULT 20,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
+    FOREIGN KEY (financial_year_id) REFERENCES financial_years (id) ON DELETE RESTRICT,
+);
+
+CREATE TABLE definitions (
     id TEXT PRIMARY KEY NOT NULL,
     user_id TEXT NOT NULL,
     name TEXT NOT NULL,
@@ -29,21 +37,19 @@ CREATE TABLE income_definitions (
     enabled_at INT NOT NULL,
     disabled_at INT NOT NULL,
     updated_at INT NOT NULL,
-    is_taxable BOOLEAN NOT NULL DEFAULT true,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT
 );
 
-CREATE TABLE income_records (
+CREATE TABLE actuals (
     user_id TEXT NOT NULL,
-    financial_month_id TEXT NOT NULL,
+    monthly_context_id TEXT NOT NULL,
     definition_id TEXT NOT NULL,
     value INT NOT NULL,
     updated_at INT NOT NULL,
-    updated_by TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
-    FOREIGN KEY (financial_month_id) REFERENCES financial_month_contexts (id) ON DELETE RESTRICT,
+    FOREIGN KEY (monthly_context_id) REFERENCES monthly_contexts (id) ON DELETE RESTRICT,
     FOREIGN KEY (definition_id) REFERENCES income_definitions (id) ON DELETE RESTRICT,
-    PRIMARY KEY (financial_month_id, definition_id)
+    PRIMARY KEY (monthly_context_id, definition_id)
 );
 
 CREATE TABLE standard_income_tables (
@@ -59,29 +65,4 @@ CREATE TABLE standard_income_grades (
     standard_income INTEGER NOT NULL,
     FOREIGN KEY (income_table_id) REFERENCES standard_income_tables (id) ON DELETE RESTRICT,
     PRIMARY KEY (income_table_id, standard_income)
-);
-
-CREATE TABLE deduction_definitions (
-    id TEXT PRIMARY KEY NOT NULL,
-    user_id TEXT NOT NULL,
-    name TEXT NOT NULL,
-    kind TEXT NOT NULL,
-    value INT NOT NULL,
-    enabled_at INT NOT NULL,
-    disabled_at INT NOT NULL,
-    updated_at INT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT
-);
-
-CREATE TABLE deduction_records (
-    user_id TEXT NOT NULL,
-    financial_month_id TEXT NOT NULL,
-    definition_id TEXT NOT NULL,
-    value INT NOT NULL,
-    updated_at INT NOT NULL,
-    updated_by TEXT NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
-    FOREIGN KEY (financial_month_id) REFERENCES financial_month_contexts (id) ON DELETE RESTRICT,
-    FOREIGN KEY (definition_id) REFERENCES deduction_definitions (id) ON DELETE RESTRICT,
-    PRIMARY KEY (financial_month_id, definition_id)
 );

--- a/backend/src/migrations/0001_create_tables.sql
+++ b/backend/src/migrations/0001_create_tables.sql
@@ -11,7 +11,7 @@ CREATE TABLE financial_years (
     user_id TEXT NOT NULL,
     year INT NOT NULL,
     standard_income_table_id TEXT NOT NULL,
-    UNIQUE (user_id, financial_year),
+    UNIQUE (user_id, year),
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
     FOREIGN KEY (standard_income_table_id) REFERENCES standard_income_tables (id) ON DELETE RESTRICT
 );
@@ -25,7 +25,7 @@ CREATE TABLE monthly_contexts (
     ended_at INT NOT NULL,
     workday INT NOT NULL DEFAULT 20,
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT,
-    FOREIGN KEY (financial_year_id) REFERENCES financial_years (id) ON DELETE RESTRICT,
+    FOREIGN KEY (financial_year_id) REFERENCES financial_years (id) ON DELETE RESTRICT
 );
 
 CREATE TABLE definitions (


### PR DESCRIPTION
Fixes: #92

- **feat: #92 会計年度エンティティに標準報酬月額を移動**
- **chore: マイグレーションファイルを更新**
- **feat: #92 会計年度エンティティ生成ロジックを追加**
- **chore: 定義を修正**
- **feat: 実績エンティティのdaoインタフェースを規定**
- **feat: 定義エンティティのdaoインタフェースを作成**
