### PR TITLE
バックエンド実装ガイドラインを拡充

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@
 - follow the guidelines:
   - frontend: @ docs/architecture-guideline/frontend.md
   - backend: @ docs/architecture-guideline/backend.md
+  - backend (page API layer): @ docs/architecture-guideline/backend-page-api.md
 - follow the specs:
   - requirements: @docs/spec/requirements.md
   - functions: @docs/spec/functions.md

--- a/docs/architecture-guideline/backend-page-api.md
+++ b/docs/architecture-guideline/backend-page-api.md
@@ -1,0 +1,150 @@
+# バックエンド実装ガイドライン（ページ API 層）
+
+> このガイドラインは [バックエンド実装ガイドライン](./backend.md) のサブガイドラインです。
+> 基本原則・レイヤ定義・命名規則は親ガイドラインに従います。
+
+---
+
+## 概要
+
+SPA において古典的な REST API を用いると、1 画面の表示に複数の API コールが直列・並列混在で発生し、ローディング状態の管理が複雑になる（popcorn UI）。
+
+これを防ぐため、**複数ドメインのデータを集約して返す Query 専用のエンドポイント層**として `pages/` を設ける。
+
+---
+
+## API 区分の判断基準
+
+| 区分 | 配置先 | 例 |
+|------|--------|----|
+| Command（登録・更新・削除） | `features/` | `POST /api/transactions` |
+| Query（単一ドメイン） | `features/` | `GET /api/categories` |
+| Query（複数ドメイン集約） | `pages/` | `GET /api/pages/dashboard` |
+
+**判断の原則**: 複数の `features/*/repository.ts` を組み合わせなければ応答を構築できない Query は `pages/` に置く。単一 feature のリポジトリだけで完結する Query は `features/` に置く。
+
+---
+
+## ディレクトリ構造
+
+```
+backend/
+├── features/              # ドメイン単位（Command + 単純 Query）
+│   └── <feature>/
+│       ├── repository.ts
+│       ├── workflow.ts
+│       └── route.ts
+│
+└── pages/                 # UI 単位（複合 Query のみ）
+    ├── dashboard/
+    │   └── route.ts       # GET /api/pages/dashboard
+    ├── analytics/
+    │   ├── categories/
+    │   │   └── route.ts   # GET /api/pages/analytics/categories
+    │   ├── savings/
+    │   │   └── route.ts   # GET /api/pages/analytics/savings
+    │   ├── events/
+    │   │   └── route.ts   # GET /api/pages/analytics/events
+    │   └── fiscal-years/
+    │       └── route.ts   # GET /api/pages/analytics/fiscal-years
+    └── scenario/
+        └── route.ts       # GET /api/pages/scenario
+```
+
+ディレクトリ名はフロントエンドのルート名と一致させる。
+
+---
+
+## 依存関係ルール
+
+```
+# features/（既存）
+route.ts → workflow.ts ← repository.ts (注入)
+              ↓
+          domains/
+
+# pages/（追加）
+route.ts → features/*/repository.ts（複数可）
+         → domains/（型参照のみ）
+```
+
+- `pages/` の route.ts は **`features/` の repository.ts を直接呼び出してよい**
+- `pages/` の route.ts は **workflow.ts を呼び出してはならない**
+- `pages/` の route.ts は **他の `pages/` モジュールに依存してはならない**
+
+---
+
+## `pages/*/route.ts` のルール
+
+### 必須
+
+- Hono インスタンスをメソッドチェーン形式で定義する（`features/` と同様）
+- レスポンス型はそのファイル内にページ固有の集約型として定義する
+- ページング用エンドポイントが必要な場合は同一ディレクトリ内に追加する
+
+### 禁止事項
+
+| # | 禁止内容 |
+|---|---------|
+| 1 | ❌ ワークフローの定義（副作用・ビジネスロジックを持たせない） |
+| 2 | ❌ Command 系処理（登録・更新・削除）の実装 |
+| 3 | ❌ `features/` のドメインモデルをそのままレスポンスとして返却 |
+| 4 | ❌ 他の `pages/` モジュールへの依存 |
+| 5 | ❌ ルート定義を変数に代入してからメソッド呼び出し（型補完が効かない） |
+
+---
+
+## 命名規則
+
+### エンドポイント URL
+
+- プレフィックス: `/api/pages/`
+- パス: フロントエンドのルートパスと対応させる
+
+```
+ダッシュボード         GET /api/pages/dashboard
+カテゴリ別年度分析     GET /api/pages/analytics/categories
+積立進捗分析           GET /api/pages/analytics/savings
+イベント別分析         GET /api/pages/analytics/events
+年度間比較             GET /api/pages/analytics/fiscal-years
+投資判断支援           GET /api/pages/scenario
+```
+
+### 集約型
+
+ページ固有の集約型は `PascalCase` で命名し、`Response` サフィックスを付ける。
+
+```typescript
+// ✅
+type DashboardResponse = {
+  balance: { internal: number; savings: number }
+  budgetProgress: { actual: number; budget: number; rate: number }
+  // ...
+}
+
+// ❌ features/ のドメインモデルをそのまま使用
+type DashboardResponse = {
+  transactions: Transaction[]
+  budgets: Budget[]
+}
+```
+
+---
+
+## 実装チェックリスト
+
+- [ ] 対象ページの表示項目を UC・機能仕様で確認し、必要なドメインを列挙する
+- [ ] 必要なドメインが複数にまたがることを確認する（単一なら `features/` に置く）
+- [ ] `pages/<page>/route.ts` を作成する
+- [ ] ページ固有の集約型（`*Response`）をファイル内に定義する
+- [ ] 各 feature のリポジトリを呼び出し、集約型に変換して返す
+- [ ] ページングが必要な場合はサブエンドポイントを追加する
+- [ ] `index.ts` で route を統合する
+
+---
+
+## 参照
+
+- [バックエンド実装ガイドライン](./backend.md)
+- [ページ API 戦略（策定経緯）](../spec-discussion/260315-page-api-strategy.md)
+- [ユースケース定義書](../spec/usecases.md)

--- a/docs/architecture-guideline/backend.md
+++ b/docs/architecture-guideline/backend.md
@@ -17,16 +17,21 @@
 ```
 backend/
 ├── domains/           # ドメインモデル定義（純粋な型のみ）
-├── features/          # 機能別レイヤ
+├── features/          # 機能別レイヤ（ドメイン単位）
 │   └── <feature>/
 │       ├── repository.ts   # 永続化層
 │       ├── workflow.ts     # ビジネスロジック
 │       ├── route.ts        # HTTPエンドポイント
 │       └── middleware.ts   # 機能固有ミドルウェア（任意）
+├── pages/             # ページ API 層（UI 単位・複合 Query 専用）
+│   └── <page>/
+│       └── route.ts        # 複数 feature を集約する読み取り専用エンドポイント
 ├── middlewares/       # 横断的関心事のミドルウェア
 ├── schemas/          # Drizzle ORMスキーマ定義
 └── lib/              # 共通ユーティリティ
 ```
+
+`pages/` の詳細なルールは [バックエンド実装ガイドライン（ページ API 層）](./backend-page-api.md) を参照。
 
 ## レイヤ定義
 
@@ -105,14 +110,20 @@ backend/
 ## 依存関係ルール
 
 ```
+# features/
 route.ts → workflow.ts ← repository.ts (注入)
               ↓
           domains/
 
 middleware.ts (feature固有) → repository.ts, workflow.ts
+
+# pages/
+pages/route.ts → features/*/repository.ts（複数可）
+              → domains/（型参照のみ）
 ```
 
-- **Route**: Workflow, Repository, Middlewareを呼び出す
+- **Route (features)**: Workflow, Repository, Middlewareを呼び出す
+- **Route (pages)**: 複数featureのRepositoryを直接呼び出す。Workflowは呼ばない
 - **Workflow**: Domainのみに依存、Repositoryは注入
 - **Repository**: Domainに依存
 - **Middleware (feature固有)**: Repository, Workflowを使用可能

--- a/docs/spec-discussion/260315-page-api-strategy.md
+++ b/docs/spec-discussion/260315-page-api-strategy.md
@@ -1,0 +1,130 @@
+# ページ API 戦略
+
+**作成日**: 2026-03-15
+**関連 issue**: #8
+
+バックエンド実装フェーズ開始にあたり、Query 系 API の設計方針として「ページ API 戦略」を採用する。本ドキュメントでその内容と理由、ディレクトリ構成への反映を記録する。
+
+---
+
+## 背景・課題
+
+古典的な REST API を SPA で使用すると、1 画面の表示に複数の API コールが発生し、ウォーターフォール状のリクエスト連鎖（いわゆる "popcorn UI"）に陥りやすい。
+
+TanStack Query を採用しているこのプロジェクトでも、`useQuery` が画面内に散在すると以下の問題が生じる：
+
+- 複数のローディング状態・エラー状態の管理が複雑になる
+- N+1 的なリクエストが発生する
+- 画面とは無関係なドメイン境界で API が分割されているため、何をフェッチすれば画面が完成するか把握しにくい
+
+特に financier のダッシュボード（UC-7.1）や分析系画面（UC-7.2〜7.7）は、複数ドメインのデータを集約して表示するため、この問題が顕著になる。
+
+---
+
+## 採用する方針
+
+### Query 系：ページ API
+
+「このページを表示するのに必要なデータをまとめて返す」エンドポイントを用意する。
+
+- リクエスト 1 本で画面全体の初期表示が完結する
+- ローディング状態が画面単位で 1 つに収まる
+- フロントエンドの repository は `GET /api/pages/{page}` を呼び出すだけになる
+
+ページングが必要な一覧（例：ダッシュボードの「もっと見る」）は、ページ専用のサブエンドポイントを追加する。
+
+### Command 系：従来の REST API
+
+登録・更新・削除などの Command 系操作は、ドメイン境界が明確であるため引き続き `features/` のエンドポイントで処理する。
+
+| 区分 | 設計 | 例 |
+|------|------|----|
+| Query（複合） | ページ API（`pages/`） | `GET /api/pages/dashboard` |
+| Query（単純） | `features/` エンドポイント | `GET /api/categories` |
+| Command | `features/` エンドポイント | `POST /api/transactions` |
+
+---
+
+## ディレクトリ構成
+
+`backend/` 直下に `pages/` ディレクトリを新設し、ページ API を配置する。既存の `features/` 構造は変更しない。
+
+```
+backend/
+├── domains/               # 変更なし
+├── schemas/               # 変更なし
+├── middlewares/           # 変更なし
+├── lib/                   # 変更なし
+│
+├── features/              # ドメイン単位（Command + 単純 Query）
+│   ├── transactions/
+│   │   ├── repository.ts
+│   │   ├── workflow.ts
+│   │   └── route.ts       # /api/transactions
+│   ├── categories/
+│   ├── budgets/
+│   ├── savings/
+│   ├── events/
+│   ├── event-templates/
+│   └── fiscal-years/
+│
+└── pages/                 # ← 新規追加：UI 単位（複合 Query）
+    ├── dashboard/
+    │   └── route.ts       # GET /api/pages/dashboard
+    ├── analytics/
+    │   ├── categories/
+    │   │   └── route.ts   # GET /api/pages/analytics/categories?fiscalYear=&month=
+    │   ├── savings/
+    │   │   └── route.ts   # GET /api/pages/analytics/savings
+    │   ├── events/
+    │   │   └── route.ts   # GET /api/pages/analytics/events
+    │   └── fiscal-years/
+    │       └── route.ts   # GET /api/pages/analytics/fiscal-years
+    └── scenario/
+        └── route.ts       # GET /api/pages/scenario?amount=  (UC-7.7)
+```
+
+---
+
+## `pages/` のルール
+
+既存のバックエンドガイドライン（[backend.md](../architecture-guideline/backend.md)）を踏襲しつつ、以下の制約を追加する。
+
+### 許可
+
+- 複数の `features/*/repository.ts` を直接呼び出す（cross-domain aggregation がこの層の存在意義）
+- ページ固有の集約型をファイル内に定義する
+- ページング用サブエンドポイントを同ディレクトリに追加する
+
+### 禁止
+
+- ワークフローの定義（read-only のため副作用・ビジネスロジックは不要）
+- `features/` のドメインモデルをそのまま返却すること（ページ用の集約型を必ず定義する）
+- Command 系の処理を `pages/` に実装すること
+
+### 依存関係
+
+```
+# 既存
+route.ts (features) → workflow.ts ← repository.ts
+                          ↓
+                      domains/
+
+# 追加
+route.ts (pages) → features/*/repository.ts（複数可）
+                 → domains/（型参照のみ）
+```
+
+---
+
+## ガイドライン更新について
+
+`backend.md` の「シンプルさ優先: 参照のみの処理はワークフローを作らずrouteレイヤで実施」という原則の延長線上にある設計であり、ガイドラインの基本方針とは矛盾しない。ただし、クロスドメイン集約を行う層として `pages/` が明示的に加わるため、実装開始前に `backend.md` のディレクトリ構造図と依存関係図を更新すること。
+
+---
+
+## 参照
+
+- [バックエンド実装ガイドライン](../architecture-guideline/backend.md)
+- [ユースケース定義書](../spec/usecases.md)（特に 7. 分析・可視化系）
+- [フロントエンドモック→API 置換対象一覧](./260312-mock-api-calls.md)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -266,8 +266,6 @@ export default defineConfig(
 
   // MARK: - Backend architecture rules
 
-  // NOTE: pages/**/*.ts は 'Avoid direct import of external package' を上書きするため、
-  // dayjs 制約を改めて含める。
   {
     name: 'backend page API rules',
     files: ['packages/app/backend/pages/**/*.ts'],
@@ -276,6 +274,7 @@ export default defineConfig(
         'error',
         {
           paths: [
+            // NOTE: dayjsの制約が上書きされてしまうため、重ねがけ
             {
               name: 'dayjs',
               message: 'Use @backend/lib/date instead',
@@ -283,18 +282,8 @@ export default defineConfig(
           ],
           patterns: [
             {
-              // ワークフローを呼び出すことは pages/ 層に許可されない
               group: ['**/workflow', '**/workflow.ts'],
-              message:
-                'pages/ のルートはワークフローを呼び出してはならない（backend-page-api.md）。',
-            },
-            {
-              // @backend/ エイリアス経由の pages 間クロスインポートを禁止する
-              // NOTE: 相対パス経由のクロスインポートはリントでは検知しきれないため、
-              //       コードレビューで確認すること
-              group: ['@backend/pages/**'],
-              message:
-                'pages/ のルートは他の pages/ モジュールに依存してはならない（backend-page-api.md）。',
+              message: 'route of pages must not import any workflows',
             },
           ],
         },
@@ -302,8 +291,6 @@ export default defineConfig(
     },
   },
 
-  // NOTE: features/**/workflow.ts は 'Avoid direct import of external package' を上書きするため、
-  // dayjs 制約を改めて含める。
   {
     name: 'backend workflow rules',
     files: ['packages/app/backend/features/**/workflow.ts'],
@@ -312,6 +299,7 @@ export default defineConfig(
         'error',
         {
           paths: [
+            // NOTE: dayjsの制約が上書きされてしまうため、重ねがけ
             {
               name: 'dayjs',
               message: 'Use @backend/lib/date instead',
@@ -319,10 +307,8 @@ export default defineConfig(
           ],
           patterns: [
             {
-              // ワークフローから直接 DB スキーマを参照することを禁止する
-              group: ['@backend/schemas', '@backend/schemas/**', '**/schemas/**'],
-              message:
-                'ワークフローから直接DBスキーマをインポートしてはならない（backend.md）。副作用はEffectsとして注入すること。',
+              group: ['**/schemas/**'],
+              message: 'workflows must not import any db schema',
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -254,13 +254,9 @@ export default defineConfig(
               name: 'dayjs',
               message: 'Use @frontend/lib/date or @backend/lib/date instead',
             },
-          ],
-          patterns: [
             {
-              // NOTE: RPC クライアントの型推論のために型インポートは許可する
-              group: ['@routes'],
-              message: 'Do not use backend types.',
-              allowTypeImports: true,
+              name: '@routes',
+              message: 'frontend must not depends on backend types',
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -125,20 +125,7 @@ export default defineConfig(
     plugins: { react: reactPlugin },
     rules: {
       'no-console': 'warn',
-      'no-restricted-imports': 'off',
       'react/hook-use-state': 'error',
-      '@typescript-eslint/no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['@routes'],
-              message: 'Do not use backend types.',
-              allowTypeImports: true,
-            },
-          ],
-        },
-      ],
       '@typescript-eslint/no-misused-promises': [
         'error',
         {
@@ -169,6 +156,8 @@ export default defineConfig(
         'error',
         { allowNumber: true },
       ],
+      // NOTE: @typescript-eslint/no-restricted-imports はここに書かない。
+      // 'Avoid direct import of external package' ブロックで一元管理する。
       '@typescript-eslint/consistent-type-imports': [
         'error',
         { prefer: 'type-imports' },
@@ -244,6 +233,102 @@ export default defineConfig(
         {
           name: 'Date',
           message: 'Use @frontend/lib/date or @backend/lib/date instead',
+        },
+      ],
+    },
+  },
+
+  // NOTE: フロントエンド固有の import 制約。
+  // 'Avoid direct import of external package' より後に置くことで
+  // @typescript-eslint/no-restricted-imports を正しく上書きする。
+  {
+    name: 'frontend import restrictions',
+    files: ['packages/app/frontend/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': 'off',
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'dayjs',
+              message: 'Use @frontend/lib/date or @backend/lib/date instead',
+            },
+          ],
+          patterns: [
+            {
+              // NOTE: RPC クライアントの型推論のために型インポートは許可する
+              group: ['@routes'],
+              message: 'Do not use backend types.',
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // MARK: - Backend architecture rules
+
+  // NOTE: pages/**/*.ts は 'Avoid direct import of external package' を上書きするため、
+  // dayjs 制約を改めて含める。
+  {
+    name: 'backend page API rules',
+    files: ['packages/app/backend/pages/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'dayjs',
+              message: 'Use @backend/lib/date instead',
+            },
+          ],
+          patterns: [
+            {
+              // ワークフローを呼び出すことは pages/ 層に許可されない
+              group: ['**/workflow', '**/workflow.ts'],
+              message:
+                'pages/ のルートはワークフローを呼び出してはならない（backend-page-api.md）。',
+            },
+            {
+              // @backend/ エイリアス経由の pages 間クロスインポートを禁止する
+              // NOTE: 相対パス経由のクロスインポートはリントでは検知しきれないため、
+              //       コードレビューで確認すること
+              group: ['@backend/pages/**'],
+              message:
+                'pages/ のルートは他の pages/ モジュールに依存してはならない（backend-page-api.md）。',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // NOTE: features/**/workflow.ts は 'Avoid direct import of external package' を上書きするため、
+  // dayjs 制約を改めて含める。
+  {
+    name: 'backend workflow rules',
+    files: ['packages/app/backend/features/**/workflow.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'dayjs',
+              message: 'Use @backend/lib/date instead',
+            },
+          ],
+          patterns: [
+            {
+              // ワークフローから直接 DB スキーマを参照することを禁止する
+              group: ['@backend/schemas', '@backend/schemas/**', '**/schemas/**'],
+              message:
+                'ワークフローから直接DBスキーマをインポートしてはならない（backend.md）。副作用はEffectsとして注入すること。',
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Fixes: #8

- **docs(spec-discussion): #8 ページAPI戦略の方針ドキュメントを追加**
- **docs(guideline): #8 ページAPI層のサブガイドラインを追加**
- **chore(eslint): #8 ページAPI層・ワークフロー層のアーキテクチャルールを追加**
- **fix(eslint): #8 フロントエンドの@routesインポート制約を修正**
- **chore: lint error message**
