### PR TITLE
feat(categories): #14 削除済みカテゴリをカテゴリ一覧に表示しないようにする

### DIFF
--- a/packages/app/backend/features/categories/repository.ts
+++ b/packages/app/backend/features/categories/repository.ts
@@ -11,7 +11,12 @@ export const findCategories =
     const results = await db
       .select()
       .from(categoriesTable)
-      .where(eq(categoriesTable.user_id, userId))
+      .where(
+        and(
+          eq(categoriesTable.user_id, userId),
+          eq(categoriesTable.status, 'active'),
+        ),
+      )
     return results.map(createCategoryModel)
   }
 

--- a/packages/app/frontend/routes/categories/index.tsx
+++ b/packages/app/frontend/routes/categories/index.tsx
@@ -130,12 +130,9 @@ const CategoriesPage: React.FC = () => {
     setDeletingCategory(null)
   }
 
-  const incomeCategories = categories.filter(
-    (c) => c.type === 'income' && c.status === 'active',
-  )
+  const incomeCategories = categories.filter((c) => c.type === 'income')
   const expenseCategories = categories.filter(
-    (c) =>
-      (c.type === 'expense' || c.type === 'saving') && c.status === 'active',
+    (c) => c.type === 'expense' || c.type === 'saving',
   )
 
   return (

--- a/packages/app/frontend/routes/categories/index.tsx
+++ b/packages/app/frontend/routes/categories/index.tsx
@@ -130,9 +130,12 @@ const CategoriesPage: React.FC = () => {
     setDeletingCategory(null)
   }
 
-  const incomeCategories = categories.filter((c) => c.type === 'income')
+  const incomeCategories = categories.filter(
+    (c) => c.type === 'income' && c.status === 'active',
+  )
   const expenseCategories = categories.filter(
-    (c) => c.type === 'expense' || c.type === 'saving',
+    (c) =>
+      (c.type === 'expense' || c.type === 'saving') && c.status === 'active',
   )
 
   return (


### PR DESCRIPTION
## 概要

- カテゴリ一覧ページで、`status: 'archived'` のカテゴリを表示しないようにした
- archivedカテゴリは外部キー制約維持のためにDB上は残すが、UIには表示しない

## 変更内容

- `incomeCategories` / `expenseCategories` のフィルタ条件に `c.status === 'active'` を追加

## 確認事項

- [x] lint (`pnpm -w lint:fix`)
- [x] format (`pnpm -w prettier:fix`)
- [x] build (`pnpm -F app build`)

Closes #14