### PR TITLE
fix(categories): #11 カテゴリダイアログを閉じたときに入力内容をリセットする

### DIFF
--- a/packages/app/frontend/routes/categories/-components/create-category-dialog.tsx
+++ b/packages/app/frontend/routes/categories/-components/create-category-dialog.tsx
@@ -64,6 +64,7 @@ export const CreateCategoryDialog: React.FC<Props> = ({
         icon: value.icon as CategoryIconType,
         color: value.color as CategoryColor,
       })
+      form.reset()
       onOpenChange(false)
     },
   })

--- a/packages/app/frontend/routes/categories/-components/edit-category-dialog.tsx
+++ b/packages/app/frontend/routes/categories/-components/edit-category-dialog.tsx
@@ -63,6 +63,7 @@ export const EditCategoryDialog: React.FC<Props> = ({
         icon: value.icon as CategoryIconType,
         color: value.color as CategoryColor,
       })
+      form.reset()
       onOpenChange(false)
     },
   })


### PR DESCRIPTION
## 概要

カテゴリ作成・更新ダイアログで、送信成功後に入力内容がリセットされず、次回開いたときに前回の値が残ってしまう問題を修正した。

## 原因

`CreateCategoryDialog` はページ内に常時マウントされ続けるため、`open` が `false` になってもコンポーネントはアンマウントされずフォーム状態が保持される。手動でダイアログを閉じる場合は `handleOpenChange` 経由で `form.reset()` が呼ばれていたが、送信成功時のパス (`onSubmit`) では `form.reset()` が呼ばれていなかった。

## 修正内容

- `create-category-dialog.tsx` / `edit-category-dialog.tsx` の `onSubmit` ハンドラで `onOpenChange(false)` の直前に `form.reset()` を追加

## テスト計画

- [x] カテゴリ作成ダイアログでカテゴリを作成し、再度ダイアログを開いたとき入力欄が空になっていることを確認
- [x] カテゴリ編集ダイアログで保存し、別のカテゴリを編集したとき正しい値が表示されることを確認
- [x] キャンセル・ダイアログ外クリックで閉じた場合も入力内容がリセットされることを確認（既存動作の確認）

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)