### PR TITLE
Upgrade actions/setup-node from v4 to v6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
Updated the `actions/setup-node` GitHub Action from v4 to v6 across CI/CD workflows to leverage the latest features and improvements.

## Changes
- Upgraded `actions/setup-node` to v6 in `.github/workflows/lint.yml`
- Upgraded `actions/setup-node` to v6 in `.github/workflows/test.yml`

## Details
Both the lint and test workflows now use the latest version of the setup-node action while maintaining the existing configuration (Node.js 22 with pnpm caching). This update ensures compatibility with the latest Node.js tooling and GitHub Actions improvements.

https://claude.ai/code/session_01MPRP6cUKMDd2seXEa8uTVU