### PR TITLE
docs(backend-page-api): ページAPI層の配置基準を設計意図に合わせて修正

### DIFF
--- a/docs/architecture-guideline/backend-page-api.md
+++ b/docs/architecture-guideline/backend-page-api.md
@@ -9,19 +9,18 @@
 
 SPA において古典的な REST API を用いると、1 画面の表示に複数の API コールが直列・並列混在で発生し、ローディング状態の管理が複雑になる（popcorn UI）。
 
-これを防ぐため、**複数ドメインのデータを集約して返す Query 専用のエンドポイント層**として `pages/` を設ける。
+これを防ぐため、**ページの表示に必要なデータを組み立てて返す Query 専用のエンドポイント層**として `pages/` を設ける。
 
 ---
 
 ## API 区分の判断基準
 
-| 区分                        | 配置先      | 例                         |
-| --------------------------- | ----------- | -------------------------- |
-| Command（登録・更新・削除） | `features/` | `POST /api/transactions`   |
-| Query（単一ドメイン）       | `features/` | `GET /api/categories`      |
-| Query（複数ドメイン集約）   | `pages/`    | `GET /api/pages/dashboard` |
+| 区分                        | 配置先      | 例                            |
+| --------------------------- | ----------- | ----------------------------- |
+| Command（登録・更新・削除） | `features/` | `POST /api/transactions`      |
+| Query（ページ表示用）       | `pages/`    | `GET /api/pages/categories`   |
 
-**判断の原則**: 複数の `features/*/repository.ts` を組み合わせなければ応答を構築できない Query は `pages/` に置く。単一 feature のリポジトリだけで完結する Query は `features/` に置く。
+**判断の原則**: ページの表示に必要なデータを組み立てて返す Query は `pages/` に置く。Command（登録・更新・削除）は `features/` に置く。
 
 ---
 


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

Issue #18 の議論を通じ、`backend-page-api.md` の判断基準が設計意図と異なることが判明したため修正します。

## 変更内容

**現行（誤り）**: 「複数ドメインのデータを集約する Query のみ `pages/`」  
**修正後（正しい設計意図）**: 「ページの表示に必要なデータを組み立てて返す Query はすべて `pages/`、Command は `features/`」

- 概要セクションの説明を修正
- API区分の判断基準テーブルから「Query（単一ドメイン）→ `features/`」行を削除し、「Query（ページ表示用）→ `pages/`」に統一
- 判断の原則を「ドメイン数」基準から「ページ表示用途」基準に変更

## 関連

- Issue #18

https://claude.ai/code/session_0192zqAgNjWQKQyKdkmvzMtK
EOF
)