### PR TITLE
feat(categories): カテゴリ一覧取得APIをページAPIへ移行

### DIFF
--- a/packages/app/backend/features/categories/route.test.ts
+++ b/packages/app/backend/features/categories/route.test.ts
@@ -69,64 +69,6 @@ describe('カテゴリAPI', () => {
     return { jwt, userId: user.id }
   }
 
-  describe('GET /', () => {
-    describe('正常系', () => {
-      let response: Awaited<ReturnType<typeof client.index.$get>>
-      let responseBody: { categories: unknown[] }
-
-      beforeAll(async () => {
-        const { jwt: sessionJwt, userId } = await setupSession()
-
-        await db.insert(categoriesTable).values([
-          {
-            id: 'test-category-id-get-000001',
-            user_id: userId,
-            type: 'income',
-            name: '給与',
-            status: 'active',
-            icon: 'briefcase',
-            color: 'green',
-          },
-          {
-            id: 'test-category-id-get-000002',
-            user_id: userId,
-            type: 'expense',
-            name: '食費',
-            status: 'active',
-            icon: 'utensils',
-            color: 'red',
-          },
-        ])
-
-        response = await client.index.$get(
-          {},
-          { headers: { Cookie: `__Host-Http-session=${sessionJwt}` } },
-        )
-        responseBody = (await response.json()) as { categories: unknown[] }
-      })
-
-      test('200が返ること', () => {
-        expect(response.status).toBe(200)
-      })
-
-      test('カテゴリ一覧が返ること', () => {
-        expect(responseBody.categories).toHaveLength(2)
-      })
-    })
-
-    describe('異常系 - セッションなし', () => {
-      let response: Awaited<ReturnType<typeof client.index.$get>>
-
-      beforeAll(async () => {
-        response = await client.index.$get({})
-      })
-
-      test('401が返ること', () => {
-        expect(response.status).toBe(401)
-      })
-    })
-  })
-
   describe('POST /', () => {
     describe('正常系 - incomeカテゴリを作成できる', () => {
       let response: Awaited<ReturnType<typeof client.index.$post>>

--- a/packages/app/backend/features/categories/route.ts
+++ b/packages/app/backend/features/categories/route.ts
@@ -10,12 +10,7 @@ import { Result } from '@praha/byethrow'
 import { Hono } from 'hono'
 
 import { CategoryNotFoundException } from './exceptions'
-import {
-  archiveCategory,
-  findCategories,
-  findCategoryById,
-  saveCategory,
-} from './repository'
+import { archiveCategory, findCategoryById, saveCategory } from './repository'
 import {
   CreateCategoryRequestSchema,
   UpdateCategoryRequestSchema,
@@ -50,15 +45,6 @@ const toCategoryResponse = (category: {
 
 const app = new Hono<{ Bindings: Env }>()
   .use(sessionMiddleware)
-  .get('/', async (c) => {
-    const session = c.get('session')
-    if (session === undefined) {
-      return c.json({ message: 'Unauthorized' }, 401)
-    }
-
-    const categories = await findCategories(c.get('db'))(session.userId)
-    return c.json({ categories: categories.map(toCategoryResponse) })
-  })
   .post('/', zValidator('json', CreateCategoryRequestSchema), async (c) => {
     const session = c.get('session')
     if (session === undefined) {

--- a/packages/app/backend/pages/categories/route.test.ts
+++ b/packages/app/backend/pages/categories/route.test.ts
@@ -1,0 +1,184 @@
+import { createSession } from '@backend/domains/session'
+import { createUser } from '@backend/domains/user'
+import { signSessionJwt } from '@backend/features/session/jwt'
+import dayjs from '@backend/lib/date'
+import {
+  SESSION_COOKIE_AGE,
+  SESSION_JWT_AGE,
+} from '@backend/lib/session-config'
+import { categoriesTable } from '@backend/schemas/categories'
+import { sessionsTable } from '@backend/schemas/sessions'
+import { usersTable } from '@backend/schemas/users'
+import { env } from 'cloudflare:test'
+import { drizzle } from 'drizzle-orm/d1'
+import { testClient } from 'hono/testing'
+import { ulid } from 'ulid'
+
+import categoriesPageRoute from './route'
+
+describe('カテゴリページAPI', () => {
+  const client = testClient(categoriesPageRoute, env)
+  const db = drizzle(env.D1)
+
+  beforeAll(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(dayjs('2022-11-01T18:05:00Z').toDate())
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  const setupSession = async (): Promise<{ jwt: string; userId: string }> => {
+    const user = createUser({
+      email: 'test@example.com',
+      idpIssuer: 'https://tenant.region.auth0.com/',
+      idpSubject: `auth0|${ulid()}`,
+    })
+
+    await db.insert(usersTable).values({
+      id: user.id,
+      email: user.email,
+      idp_iss: user.idpIssuer,
+      idp_sub: user.idpSubject,
+    })
+
+    const now = dayjs()
+    const session = createSession({
+      user,
+      expiresAt: now.add(SESSION_COOKIE_AGE, 'second'),
+      idpSessionId: 'idp-session-123',
+    })
+
+    await db.insert(sessionsTable).values({
+      id: session.id,
+      user_id: session.userId,
+      issued_at: session.issuedAt.toISOString(),
+      expires_at: session.expiresAt.toISOString(),
+      idp_session_id: session.idpSessionId,
+    })
+
+    const jwt = await signSessionJwt(env.SESSION_SECRET)({
+      sessionId: session.id,
+      userId: user.id,
+      now,
+      expiresIn: SESSION_JWT_AGE,
+    })
+
+    return { jwt, userId: user.id }
+  }
+
+  describe('GET /', () => {
+    describe('正常系 - カテゴリ一覧を取得できる', () => {
+      let response: Awaited<ReturnType<typeof client.index.$get>>
+      let responseBody: { categories: Record<string, unknown>[] }
+
+      beforeAll(async () => {
+        const { jwt: sessionJwt, userId } = await setupSession()
+
+        await db.insert(categoriesTable).values([
+          {
+            id: `cat-page-${ulid()}`,
+            user_id: userId,
+            type: 'income',
+            name: '給与',
+            status: 'active',
+            icon: 'briefcase',
+            color: 'green',
+          },
+          {
+            id: `cat-page-${ulid()}`,
+            user_id: userId,
+            type: 'expense',
+            name: '食費',
+            status: 'active',
+            icon: 'utensils',
+            color: 'red',
+          },
+        ])
+
+        response = await client.index.$get(
+          {},
+          { headers: { Cookie: `__Host-Http-session=${sessionJwt}` } },
+        )
+        responseBody = (await response.json()) as typeof responseBody
+      })
+
+      test('200が返ること', () => {
+        expect(response.status).toBe(200)
+      })
+
+      test('カテゴリ一覧が返ること', () => {
+        expect(responseBody.categories).toHaveLength(2)
+      })
+
+      test('statusフィールドが含まれないこと', () => {
+        for (const cat of responseBody.categories) {
+          expect(cat).not.toHaveProperty('status')
+        }
+      })
+
+      test('userIdフィールドが含まれないこと', () => {
+        for (const cat of responseBody.categories) {
+          expect(cat).not.toHaveProperty('userId')
+        }
+      })
+    })
+
+    describe('正常系 - アーカイブ済みカテゴリは返らないこと', () => {
+      let response: Awaited<ReturnType<typeof client.index.$get>>
+      let responseBody: { categories: unknown[] }
+
+      beforeAll(async () => {
+        const { jwt: sessionJwt, userId } = await setupSession()
+
+        await db.insert(categoriesTable).values([
+          {
+            id: `cat-page-${ulid()}`,
+            user_id: userId,
+            type: 'expense',
+            name: 'アクティブカテゴリ',
+            status: 'active',
+            icon: 'tag',
+            color: 'blue',
+          },
+          {
+            id: `cat-page-${ulid()}`,
+            user_id: userId,
+            type: 'expense',
+            name: 'アーカイブ済みカテゴリ',
+            status: 'archived',
+            icon: 'tag',
+            color: 'red',
+          },
+        ])
+
+        response = await client.index.$get(
+          {},
+          { headers: { Cookie: `__Host-Http-session=${sessionJwt}` } },
+        )
+        responseBody = (await response.json()) as typeof responseBody
+      })
+
+      test('200が返ること', () => {
+        expect(response.status).toBe(200)
+      })
+
+      test('アクティブなカテゴリのみ返ること', () => {
+        expect(responseBody.categories).toHaveLength(1)
+      })
+    })
+
+    describe('異常系 - セッションなし', () => {
+      let response: Awaited<ReturnType<typeof client.index.$get>>
+
+      beforeAll(async () => {
+        response = await client.index.$get({})
+      })
+
+      test('401が返ること', () => {
+        expect(response.status).toBe(401)
+      })
+    })
+  })
+})

--- a/packages/app/backend/pages/categories/route.ts
+++ b/packages/app/backend/pages/categories/route.ts
@@ -1,0 +1,34 @@
+import { findCategories } from '@backend/features/categories/repository'
+import { sessionMiddleware } from '@backend/features/session/middleware'
+import { Hono } from 'hono'
+
+type CategoryListItemResponse = {
+  id: string
+  type: 'income' | 'expense' | 'saving'
+  name: string
+  icon: string
+  color: string
+}
+
+const app = new Hono<{ Bindings: Env }>()
+  .use(sessionMiddleware)
+  .get('/', async (c) => {
+    const session = c.get('session')
+    if (session === undefined) {
+      return c.json({ message: 'Unauthorized' }, 401)
+    }
+
+    const categories = await findCategories(c.get('db'))(session.userId)
+
+    const items: CategoryListItemResponse[] = categories.map((cat) => ({
+      id: cat.id,
+      type: cat.type,
+      name: cat.name,
+      icon: cat.icon,
+      color: cat.color,
+    }))
+
+    return c.json({ categories: items })
+  })
+
+export default app

--- a/packages/app/backend/pages/index.ts
+++ b/packages/app/backend/pages/index.ts
@@ -1,6 +1,9 @@
+import categoriesPageRoute from '@backend/pages/categories/route'
 import eventsPageRoute from '@backend/pages/events/route'
 import { Hono } from 'hono'
 
-const app = new Hono<{ Bindings: Env }>().route('/events', eventsPageRoute)
+const app = new Hono<{ Bindings: Env }>()
+  .route('/categories', categoriesPageRoute)
+  .route('/events', eventsPageRoute)
 
 export default app

--- a/packages/app/frontend/routes/categories/-components/category-table.tsx
+++ b/packages/app/frontend/routes/categories/-components/category-table.tsx
@@ -44,10 +44,7 @@ export const CategoryTable: React.FC<CategoryTableProps> = ({
       </TableHeader>
       <TableBody>
         {categories.map((category) => (
-          <TableRow
-            key={category.id}
-            className={category.status === 'archived' ? 'opacity-50' : ''}
-          >
+          <TableRow key={category.id}>
             <TableCell>
               <div className="flex items-center gap-2">
                 <CategoryIcon
@@ -59,40 +56,33 @@ export const CategoryTable: React.FC<CategoryTableProps> = ({
               </div>
             </TableCell>
             <TableCell>
-              <div className="flex gap-1">
-                {category.type === 'saving' && (
-                  <Badge variant="secondary">積立</Badge>
-                )}
-                {category.status === 'archived' && (
-                  <Badge variant="outline">削除済み</Badge>
-                )}
-              </div>
+              {category.type === 'saving' && (
+                <Badge variant="secondary">積立</Badge>
+              )}
             </TableCell>
             <TableCell>
-              {category.status === 'active' && (
-                <div className="flex justify-end gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => {
-                      onEdit(category)
-                    }}
-                    aria-label="編集"
-                  >
-                    <Pencil />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => {
-                      onDelete(category)
-                    }}
-                    aria-label="削除"
-                  >
-                    <Trash2 />
-                  </Button>
-                </div>
-              )}
+              <div className="flex justify-end gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => {
+                    onEdit(category)
+                  }}
+                  aria-label="編集"
+                >
+                  <Pencil />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => {
+                    onDelete(category)
+                  }}
+                  aria-label="削除"
+                >
+                  <Trash2 />
+                </Button>
+              </div>
             </TableCell>
           </TableRow>
         ))}

--- a/packages/app/frontend/routes/categories/-components/create-category-dialog.tsx
+++ b/packages/app/frontend/routes/categories/-components/create-category-dialog.tsx
@@ -41,7 +41,7 @@ type Props = {
   type: 'income' | 'expense'
   open: boolean
   onOpenChange: (open: boolean) => void
-  onCreate: (category: Omit<Category, 'id' | 'status'>) => Promise<void>
+  onCreate: (category: Omit<Category, 'id'>) => Promise<void>
 }
 
 export const CreateCategoryDialog: React.FC<Props> = ({

--- a/packages/app/frontend/routes/categories/-repositories/categories.ts
+++ b/packages/app/frontend/routes/categories/-repositories/categories.ts
@@ -2,12 +2,12 @@ import { client } from '@frontend/lib/client'
 import type { InferRequestType, InferResponseType } from 'hono/client'
 
 export type CategoryItem = InferResponseType<
-  typeof client.categories.$get,
+  typeof client.pages.categories.$get,
   200
 >['categories'][number]
 
 const fetchCategories = async (): Promise<CategoryItem[]> => {
-  const response = await client.categories.$get()
+  const response = await client.pages.categories.$get()
   if (!response.ok) {
     throw new Error('カテゴリの取得に失敗しました')
   }

--- a/packages/app/frontend/routes/categories/index.tsx
+++ b/packages/app/frontend/routes/categories/index.tsx
@@ -26,13 +26,11 @@ import {
 } from './-repositories/categories'
 
 export type CategoryType = 'income' | 'expense' | 'saving'
-export type CategoryStatus = 'active' | 'archived'
 
 export type Category = {
   id: string
   type: CategoryType
   name: string
-  status: CategoryStatus
   icon: CategoryIconType
   color: CategoryColor
 }
@@ -44,7 +42,6 @@ const CategoriesPage: React.FC = () => {
     id: c.id,
     type: c.type as CategoryType,
     name: c.name,
-    status: c.status as CategoryStatus,
     icon: c.icon as CategoryIconType,
     color: c.color as CategoryColor,
   }))
@@ -57,7 +54,7 @@ const CategoriesPage: React.FC = () => {
   )
 
   const createMutation = useMutation({
-    mutationFn: (data: Omit<Category, 'id' | 'status'>) =>
+    mutationFn: (data: Omit<Category, 'id'>) =>
       createCategory({
         type: data.type,
         name: data.name,
@@ -97,9 +94,7 @@ const CategoriesPage: React.FC = () => {
     },
   })
 
-  const handleCreate = async (
-    data: Omit<Category, 'id' | 'status'>,
-  ): Promise<void> => {
+  const handleCreate = async (data: Omit<Category, 'id'>): Promise<void> => {
     await createMutation.mutateAsync(data)
   }
 

--- a/packages/app/frontend/routes/events/-components/event-transaction-section.tsx
+++ b/packages/app/frontend/routes/events/-components/event-transaction-section.tsx
@@ -100,7 +100,7 @@ export const EventTransactionSection: React.FC<Props> = ({
   const formCategories = useMemo(
     () =>
       (categoriesData ?? [])
-        .filter((c) => c.status === 'active' && c.type !== 'saving')
+        .filter((c) => c.type !== 'saving')
         .map((c) => ({
           id: c.id,
           name: c.name,

--- a/packages/app/frontend/routes/transactions/index.tsx
+++ b/packages/app/frontend/routes/transactions/index.tsx
@@ -88,15 +88,13 @@ const TransactionsPage: React.FC = () => {
 
   const formCategories = useMemo(
     () =>
-      (categoriesData ?? [])
-        .filter((c) => c.status === 'active')
-        .map((c) => ({
-          id: c.id,
-          name: c.name,
-          type: c.type,
-          icon: c.icon as CategoryIconType,
-          color: c.color as CategoryColor,
-        })),
+      (categoriesData ?? []).map((c) => ({
+        id: c.id,
+        name: c.name,
+        type: c.type,
+        icon: c.icon as CategoryIconType,
+        color: c.color as CategoryColor,
+      })),
     [categoriesData],
   )
 


### PR DESCRIPTION
PR#31によるコンポーネント分割後のmainへの適用。
- backend: pages/categories/route.ts を新規作成し GET /api/pages/categories を実装
- backend: features/categories/route.ts から GET / を削除
- frontend: CategoryItem の型推論を client.pages.categories.$get に切り替え
- frontend: Category 型から status / CategoryStatus を削除
- frontend: category-table.tsx の status 参照（opacity-50、削除済みバッジ、条件分岐）を除去
- frontend: transactions / event-transaction-section の status フィルターを削除

https://claude.ai/code/session_0119PwvAcECofz2iqFuWwpKE