### PR TITLE
feat(event-templates): #34 フロントエンドをAPIに接続

### DIFF
--- a/packages/app/frontend/routes/event-templates/$id/edit/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/edit/index.tsx
@@ -1,34 +1,82 @@
+import type {
+  CategoryColor,
+  CategoryIconType,
+} from '@frontend/components/category/types'
 import { Button } from '@frontend/components/ui/button'
+import { listCategoriesQueryOptions } from '@frontend/routes/categories/-repositories/categories'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ArrowLeftIcon, Loader2Icon } from 'lucide-react'
+import { toast } from 'sonner'
 
-import { TEMPLATE_DETAILS } from '../../-components/template-data'
 import { TemplateFormFields } from '../../-components/template-form-fields'
 import { useTemplateForm } from '../../-components/use-template-form'
+import {
+  getEventTemplateDetailQueryOptions,
+  updateEventTemplate,
+} from '../../-repositories/event-templates'
 
 const EventTemplateEditPage: React.FC = () => {
   const { id } = Route.useParams()
   const navigate = useNavigate()
-  const original = TEMPLATE_DETAILS[id]
+  const queryClient = useQueryClient()
+
+  const { data: template, isPending: templatePending } = useQuery(
+    getEventTemplateDetailQueryOptions(id),
+  )
+  const { data: categoriesData } = useQuery(listCategoriesQueryOptions())
+
+  const categories = (categoriesData ?? [])
+    .filter((c) => c.type !== 'saving')
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      icon: c.icon as CategoryIconType,
+      color: c.color as CategoryColor,
+    }))
+
+  const mutation = useMutation({
+    mutationFn: (body: Parameters<typeof updateEventTemplate>[1]) =>
+      updateEventTemplate(id, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['event-templates'] })
+      void navigate({ to: '/event-templates/$id', params: { id } })
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
 
   const form = useTemplateForm(
     {
-      templateName: original?.name,
-      items: original?.items.map((it) => ({
+      templateName: template?.name,
+      items: template?.items.map((it) => ({
         categoryId: it.categoryId,
         name: it.name,
-        amount: String(it.amount),
-        type: it.type,
+        amount: String(it.defaultAmount),
       })),
     },
-    async () => {
-      // モック：実際にはAPIを呼び出してテンプレートを更新する
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      void navigate({ to: '/event-templates/$id', params: { id } })
+    async (value) => {
+      await mutation.mutateAsync({
+        name: value.templateName,
+        defaultTransactions: value.items.map((item) => ({
+          categoryId: item.categoryId,
+          name: item.name,
+          amount: parseInt(item.amount, 10),
+        })),
+      })
     },
   )
 
-  if (!original) {
+  if (templatePending) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        読み込み中...
+      </p>
+    )
+  }
+
+  if (!template) {
     return (
       <div className="space-y-4">
         <Button asChild variant="ghost" size="sm">
@@ -61,7 +109,7 @@ const EventTemplateEditPage: React.FC = () => {
           await form.handleSubmit()
         }}
       >
-        <TemplateFormFields form={form} />
+        <TemplateFormFields form={form} categories={categories} />
 
         <form.Subscribe
           selector={(state) => state.isSubmitting}

--- a/packages/app/frontend/routes/event-templates/$id/edit/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/edit/index.tsx
@@ -56,16 +56,15 @@ const EventTemplateEditPage: React.FC = () => {
         amount: String(it.defaultAmount),
       })),
     },
-    async (value) => {
-      await mutation.mutateAsync({
+    (value) =>
+      mutation.mutateAsync({
         name: value.templateName,
         defaultTransactions: value.items.map((item) => ({
           categoryId: item.categoryId,
           name: item.name,
           amount: parseInt(item.amount, 10),
         })),
-      })
-    },
+      }),
   )
 
   if (templatePending) {

--- a/packages/app/frontend/routes/event-templates/$id/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/index.tsx
@@ -162,8 +162,8 @@ const EventTemplateDetailPage: React.FC = () => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {template.items.map((item, index) => (
-                <TableRow key={index}>
+              {template.items.map((item) => (
+                <TableRow key={item.categoryId}>
                   <TableCell className="py-2 pl-6 text-xs">
                     {item.type === 'income' ? (
                       <span className="text-emerald-600">収入</span>

--- a/packages/app/frontend/routes/event-templates/$id/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/index.tsx
@@ -25,25 +25,50 @@ import {
   TableHeader,
   TableRow,
 } from '@frontend/components/ui/table'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ArrowLeftIcon, PencilIcon, Trash2Icon } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { RegisterEventButton } from '../-components/register-event-button'
-import { TEMPLATE_DETAILS } from '../-components/template-data'
+import {
+  deleteEventTemplate,
+  getEventTemplateDetailQueryOptions,
+} from '../-repositories/event-templates'
 
 const formatCurrency = (amount: number) => `¥${amount.toLocaleString('ja-JP')}`
 
 const EventTemplateDetailPage: React.FC = () => {
   const { id } = Route.useParams()
   const navigate = useNavigate()
-  const template = TEMPLATE_DETAILS[id]
+  const queryClient = useQueryClient()
 
-  const handleDelete = () => {
-    // モック：実際にはAPIを呼び出してテンプレートを削除する
-    void navigate({ to: '/event-templates' })
+  const {
+    data: template,
+    isPending,
+    isError,
+  } = useQuery(getEventTemplateDetailQueryOptions(id))
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteEventTemplate(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['event-templates'] })
+      void navigate({ to: '/event-templates' })
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  if (isPending) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        読み込み中...
+      </p>
+    )
   }
 
-  if (!template) {
+  if (isError || !template) {
     return (
       <div className="space-y-4">
         <Button asChild variant="ghost" size="sm">
@@ -58,7 +83,8 @@ const EventTemplateDetailPage: React.FC = () => {
   }
 
   const netDefault = template.items.reduce(
-    (sum, it) => sum + (it.type === 'income' ? it.amount : -it.amount),
+    (sum, it) =>
+      sum + (it.type === 'income' ? it.defaultAmount : -it.defaultAmount),
     0,
   )
 
@@ -104,7 +130,11 @@ const EventTemplateDetailPage: React.FC = () => {
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>キャンセル</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleDelete}>
+                  <AlertDialogAction
+                    onClick={() => {
+                      deleteMutation.mutate()
+                    }}
+                  >
                     削除する
                   </AlertDialogAction>
                 </AlertDialogFooter>
@@ -132,8 +162,8 @@ const EventTemplateDetailPage: React.FC = () => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {template.items.map((item) => (
-                <TableRow key={item.id}>
+              {template.items.map((item, index) => (
+                <TableRow key={index}>
                   <TableCell className="py-2 pl-6 text-xs">
                     {item.type === 'income' ? (
                       <span className="text-emerald-600">収入</span>
@@ -147,7 +177,7 @@ const EventTemplateDetailPage: React.FC = () => {
                   <TableCell className="py-2 text-xs">{item.name}</TableCell>
                   <TableCell className="py-2 pr-6 text-right font-mono text-xs">
                     {item.type === 'income' ? '+' : '-'}
-                    {formatCurrency(item.amount)}
+                    {formatCurrency(item.defaultAmount)}
                   </TableCell>
                 </TableRow>
               ))}

--- a/packages/app/frontend/routes/event-templates/$id/register/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/register/index.tsx
@@ -1,64 +1,82 @@
 import { Button } from '@frontend/components/ui/button'
-import { Calendar } from '@frontend/components/ui/calendar'
-import { Field, FieldLabel } from '@frontend/components/ui/field'
-import { Input } from '@frontend/components/ui/input'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@frontend/components/ui/popover'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@frontend/components/ui/table'
 import dayjs from '@frontend/lib/date'
 import { useForm } from '@tanstack/react-form'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
-import { ArrowLeftIcon, CalendarIcon, Loader2Icon } from 'lucide-react'
+import { ArrowLeftIcon, Loader2Icon } from 'lucide-react'
+import { toast } from 'sonner'
 import { z } from 'zod'
 
-import { TEMPLATE_DETAILS } from '../../-components/template-data'
+import { DatePickerField } from '../../-components/date-picker-field'
+import type { RegisterItem } from '../../-components/register-items-table'
+import { RegisterItemsTable } from '../../-components/register-items-table'
+import {
+  getEventTemplateDetailQueryOptions,
+  registerEventTemplate,
+} from '../../-repositories/event-templates'
 
 const formatCurrency = (amount: number) => `¥${amount.toLocaleString('ja-JP')}`
 
 const formSchema = z.object({
   date: z.string().min(1, '取引日を入力してください'),
   items: z.array(
-    z.object({
-      id: z.string(),
-      amount: z.string(),
-    }),
+    z.object({ categoryId: z.string(), name: z.string(), amount: z.string() }),
   ),
 })
 
 const EventTemplateRegisterPage: React.FC = () => {
   const { id } = Route.useParams()
   const navigate = useNavigate()
-  const template = TEMPLATE_DETAILS[id]
+  const queryClient = useQueryClient()
+
+  const { data: template, isPending } = useQuery(
+    getEventTemplateDetailQueryOptions(id),
+  )
+
+  const mutation = useMutation({
+    mutationFn: (body: Parameters<typeof registerEventTemplate>[1]) =>
+      registerEventTemplate(id, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['transactions'] })
+      void queryClient.invalidateQueries({ queryKey: ['events'] })
+      void navigate({ to: '/event-templates/$id', params: { id } })
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
 
   const form = useForm({
     defaultValues: {
       date: dayjs().format('YYYY-MM-DD'),
       items: template
         ? template.items.map((item) => ({
-            id: item.id,
-            amount: String(item.amount),
+            categoryId: item.categoryId,
+            name: item.name,
+            amount: String(item.defaultAmount),
           }))
         : [],
     },
-    validators: {
-      onSubmit: formSchema,
-    },
-    onSubmit: async () => {
-      // モック：実際にはAPIを呼び出してトランザクションを一括作成する
-      await new Promise((resolve) => setTimeout(resolve, 1000))
-      void navigate({ to: '/event-templates/$id', params: { id } })
+    validators: { onSubmit: formSchema },
+    onSubmit: async ({ value }) => {
+      await mutation.mutateAsync({
+        occurredOn: value.date,
+        items: value.items.map((item) => ({
+          categoryId: item.categoryId,
+          name: item.name,
+          amount: parseInt(item.amount, 10),
+        })),
+      })
     },
   })
+
+  if (isPending) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        読み込み中...
+      </p>
+    )
+  }
 
   if (!template) {
     return (
@@ -95,98 +113,41 @@ const EventTemplateRegisterPage: React.FC = () => {
       >
         <form.Field
           name="date"
-          children={(field) => {
-            const selectedDate = field.state.value
-              ? dayjs(field.state.value).toDate()
-              : undefined
+          children={(field) => (
+            <DatePickerField
+              id="bulk-date"
+              label="取引日（全件共通）"
+              value={field.state.value}
+              onChange={field.handleChange}
+              onBlur={field.handleBlur}
+            />
+          )}
+        />
+
+        <form.Subscribe
+          selector={(state) => state.values.items}
+          children={(formItems) => {
+            const tableItems: RegisterItem[] = template.items.map(
+              (item, index) => ({
+                categoryName: item.categoryName,
+                name: item.name,
+                type: item.type,
+                amount: formItems[index]?.amount ?? String(item.defaultAmount),
+              }),
+            )
             return (
-              <Field>
-                <FieldLabel htmlFor="bulk-date">取引日（全件共通）</FieldLabel>
-                <Popover
-                  onOpenChange={(popoverOpen) => {
-                    if (!popoverOpen) field.handleBlur()
-                  }}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="bulk-date"
-                      type="button"
-                      variant="outline"
-                      className={
-                        selectedDate
-                          ? 'w-full justify-start text-left font-normal'
-                          : 'w-full justify-start text-left font-normal text-muted-foreground'
-                      }
-                    >
-                      <CalendarIcon />
-                      {selectedDate
-                        ? dayjs(selectedDate).format('YYYY/MM/DD')
-                        : '日付を選択'}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={selectedDate}
-                      onSelect={(d) => {
-                        field.handleChange(
-                          d ? dayjs(d).format('YYYY-MM-DD') : '',
-                        )
-                      }}
-                    />
-                  </PopoverContent>
-                </Popover>
-              </Field>
+              <RegisterItemsTable
+                items={tableItems}
+                onAmountChange={(index, value) => {
+                  form.setFieldValue(`items[${index}].amount`, value)
+                }}
+                onAmountBlur={(index) => {
+                  void form.validateField(`items[${index}].amount`, 'blur')
+                }}
+              />
             )
           }}
         />
-
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="h-8 text-xs">種別</TableHead>
-              <TableHead className="h-8 text-xs">カテゴリ</TableHead>
-              <TableHead className="h-8 text-xs">内容</TableHead>
-              <TableHead className="h-8 text-right text-xs">
-                金額（円）
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {template.items.map((item, index) => (
-              <TableRow key={item.id}>
-                <TableCell className="py-2 text-xs">
-                  {item.type === 'income' ? (
-                    <span className="text-emerald-600">収入</span>
-                  ) : (
-                    <span className="text-rose-600">支出</span>
-                  )}
-                </TableCell>
-                <TableCell className="py-2 text-xs">
-                  {item.categoryName}
-                </TableCell>
-                <TableCell className="py-2 text-xs">{item.name}</TableCell>
-                <TableCell className="py-2 text-right">
-                  <form.Field
-                    name={`items[${index}].amount`}
-                    children={(field) => (
-                      <Input
-                        type="number"
-                        min={0}
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => {
-                          field.handleChange(e.target.value)
-                        }}
-                        className="h-7 w-28 text-right text-xs"
-                      />
-                    )}
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
 
         <form.Subscribe
           selector={(state) =>

--- a/packages/app/frontend/routes/event-templates/$id/register/index.tsx
+++ b/packages/app/frontend/routes/event-templates/$id/register/index.tsx
@@ -58,16 +58,15 @@ const EventTemplateRegisterPage: React.FC = () => {
         : [],
     },
     validators: { onSubmit: formSchema },
-    onSubmit: async ({ value }) => {
-      await mutation.mutateAsync({
+    onSubmit: ({ value }) =>
+      mutation.mutateAsync({
         occurredOn: value.date,
         items: value.items.map((item) => ({
           categoryId: item.categoryId,
           name: item.name,
           amount: parseInt(item.amount, 10),
         })),
-      })
-    },
+      }),
   })
 
   if (isPending) {

--- a/packages/app/frontend/routes/event-templates/-components/date-picker-field.tsx
+++ b/packages/app/frontend/routes/event-templates/-components/date-picker-field.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@frontend/components/ui/button'
+import { Calendar } from '@frontend/components/ui/calendar'
+import { Field, FieldLabel } from '@frontend/components/ui/field'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@frontend/components/ui/popover'
+import dayjs from '@frontend/lib/date'
+import { CalendarIcon } from 'lucide-react'
+
+type Props = {
+  id: string
+  label: string
+  value: string
+  onChange: (value: string) => void
+  onBlur: () => void
+}
+
+export const DatePickerField: React.FC<Props> = ({
+  id,
+  label,
+  value,
+  onChange,
+  onBlur,
+}) => {
+  const selectedDate = value ? dayjs(value).toDate() : undefined
+  return (
+    <Field>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Popover
+        onOpenChange={(open) => {
+          if (!open) onBlur()
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            className={
+              selectedDate
+                ? 'w-full justify-start text-left font-normal'
+                : 'w-full justify-start text-left font-normal text-muted-foreground'
+            }
+          >
+            <CalendarIcon />
+            {selectedDate
+              ? dayjs(selectedDate).format('YYYY/MM/DD')
+              : '日付を選択'}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={(d) => {
+              onChange(d ? dayjs(d).format('YYYY-MM-DD') : '')
+            }}
+          />
+        </PopoverContent>
+      </Popover>
+    </Field>
+  )
+}

--- a/packages/app/frontend/routes/event-templates/-components/register-items-table.tsx
+++ b/packages/app/frontend/routes/event-templates/-components/register-items-table.tsx
@@ -1,0 +1,68 @@
+import { Input } from '@frontend/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@frontend/components/ui/table'
+
+export type RegisterItem = {
+  categoryName: string
+  name: string
+  type: 'income' | 'expense'
+  amount: string
+}
+
+type Props = {
+  items: RegisterItem[]
+  onAmountChange: (index: number, value: string) => void
+  onAmountBlur: (index: number) => void
+}
+
+export const RegisterItemsTable: React.FC<Props> = ({
+  items,
+  onAmountChange,
+  onAmountBlur,
+}) => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="h-8 text-xs">種別</TableHead>
+        <TableHead className="h-8 text-xs">カテゴリ</TableHead>
+        <TableHead className="h-8 text-xs">内容</TableHead>
+        <TableHead className="h-8 text-right text-xs">金額（円）</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {items.map((item, index) => (
+        <TableRow key={index}>
+          <TableCell className="py-2 text-xs">
+            {item.type === 'income' ? (
+              <span className="text-emerald-600">収入</span>
+            ) : (
+              <span className="text-rose-600">支出</span>
+            )}
+          </TableCell>
+          <TableCell className="py-2 text-xs">{item.categoryName}</TableCell>
+          <TableCell className="py-2 text-xs">{item.name}</TableCell>
+          <TableCell className="py-2 text-right">
+            <Input
+              type="number"
+              min={0}
+              value={item.amount}
+              onBlur={() => {
+                onAmountBlur(index)
+              }}
+              onChange={(e) => {
+                onAmountChange(index, e.target.value)
+              }}
+              className="h-7 w-28 text-right text-xs"
+            />
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)

--- a/packages/app/frontend/routes/event-templates/-components/template-form-fields.tsx
+++ b/packages/app/frontend/routes/event-templates/-components/template-form-fields.tsx
@@ -1,3 +1,4 @@
+import type { CategorySelectItem } from '@frontend/components/category/category-select'
 import { Button } from '@frontend/components/ui/button'
 import { Field, FieldError, FieldLabel } from '@frontend/components/ui/field'
 import { Input } from '@frontend/components/ui/input'
@@ -10,9 +11,10 @@ import { newFormItemValues } from './use-template-form'
 
 type Props = {
   form: ReturnType<typeof useTemplateForm>
+  categories: CategorySelectItem[]
 }
 
-export const TemplateFormFields: React.FC<Props> = ({ form }) => (
+export const TemplateFormFields: React.FC<Props> = ({ form, categories }) => (
   <>
     <form.Field
       name="templateName"
@@ -56,6 +58,7 @@ export const TemplateFormFields: React.FC<Props> = ({ form }) => (
                 onRemove={() => {
                   field.removeValue(index)
                 }}
+                categories={categories}
               />
             ))}
             <Button

--- a/packages/app/frontend/routes/event-templates/-components/template-form-item.tsx
+++ b/packages/app/frontend/routes/event-templates/-components/template-form-item.tsx
@@ -1,8 +1,5 @@
+import type { CategorySelectItem } from '@frontend/components/category/category-select'
 import { CategorySelect } from '@frontend/components/category/category-select'
-import type {
-  CategoryColor,
-  CategoryIconType,
-} from '@frontend/components/category/types'
 import { Button } from '@frontend/components/ui/button'
 import {
   Card,
@@ -18,38 +15,16 @@ import {
   InputGroupInput,
   InputGroupText,
 } from '@frontend/components/ui/input-group'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@frontend/components/ui/select'
 import { Trash2Icon } from 'lucide-react'
 
 import type { useTemplateForm } from './use-template-form'
-
-// 選択可能カテゴリ：isSaving=false のアクティブカテゴリのみ（UC-5.4）
-export const SELECTABLE_CATEGORIES: {
-  id: string
-  name: string
-  icon: CategoryIconType
-  color: CategoryColor
-}[] = [
-  { id: 'cat-1', name: '食費', icon: 'utensils', color: 'red' },
-  { id: 'cat-2', name: '交通費', icon: 'bus', color: 'blue' },
-  { id: 'cat-3', name: '外食', icon: 'coffee', color: 'orange' },
-  { id: 'cat-4', name: '娯楽・グッズ', icon: 'music', color: 'purple' },
-  { id: 'cat-5', name: '衣服', icon: 'shirt', color: 'pink' },
-  { id: 'cat-6', name: '日用品', icon: 'shopping_cart', color: 'teal' },
-  { id: 'cat-7', name: '美容', icon: 'heart_pulse', color: 'pink' },
-]
 
 type Props = {
   form: ReturnType<typeof useTemplateForm>
   index: number
   canRemove: boolean
   onRemove: () => void
+  categories: CategorySelectItem[]
 }
 
 export const TemplateFormItem: React.FC<Props> = ({
@@ -57,6 +32,7 @@ export const TemplateFormItem: React.FC<Props> = ({
   index,
   canRemove,
   onRemove,
+  categories,
 }) => (
   <Card>
     <CardHeader className="pb-2 pt-3 px-4">
@@ -73,29 +49,6 @@ export const TemplateFormItem: React.FC<Props> = ({
     </CardHeader>
     <CardContent className="px-4 pb-4 space-y-3">
       <form.Field
-        name={`items[${index}].type`}
-        children={(field) => (
-          <Field>
-            <FieldLabel htmlFor={`type-${index}`}>種別</FieldLabel>
-            <Select
-              value={field.state.value}
-              onValueChange={(v: 'income' | 'expense') => {
-                field.handleChange(v)
-              }}
-            >
-              <SelectTrigger id={`type-${index}`} className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="income">収入</SelectItem>
-                <SelectItem value="expense">支出</SelectItem>
-              </SelectContent>
-            </Select>
-          </Field>
-        )}
-      />
-
-      <form.Field
         name={`items[${index}].categoryId`}
         children={(field) => {
           const isInvalid =
@@ -107,7 +60,7 @@ export const TemplateFormItem: React.FC<Props> = ({
                 id={`cat-${index}`}
                 className="w-full"
                 aria-invalid={isInvalid}
-                categories={SELECTABLE_CATEGORIES}
+                categories={categories}
                 value={field.state.value}
                 onValueChange={(v) => {
                   field.handleChange(v)

--- a/packages/app/frontend/routes/event-templates/-components/use-template-form.ts
+++ b/packages/app/frontend/routes/event-templates/-components/use-template-form.ts
@@ -7,7 +7,6 @@ const itemSchema = z.object({
   amount: z
     .string()
     .refine((v) => parseInt(v, 10) > 0, '1以上の金額を入力してください'),
-  type: z.enum(['income', 'expense']),
 })
 
 export const templateFormSchema = z.object({
@@ -19,14 +18,12 @@ export type FormItemValues = {
   categoryId: string
   name: string
   amount: string
-  type: 'income' | 'expense'
 }
 
 export const newFormItemValues = (): FormItemValues => ({
   categoryId: '',
   name: '',
   amount: '',
-  type: 'expense',
 })
 
 export const useTemplateForm = (

--- a/packages/app/frontend/routes/event-templates/-repositories/event-templates.ts
+++ b/packages/app/frontend/routes/event-templates/-repositories/event-templates.ts
@@ -1,0 +1,109 @@
+import { client } from '@frontend/lib/client'
+import type { InferRequestType, InferResponseType } from 'hono/client'
+
+export type EventTemplateSummary = InferResponseType<
+  (typeof client.pages)['event-templates']['$get'],
+  200
+>['templates'][number]
+
+export type EventTemplateDetail = NonNullable<
+  InferResponseType<
+    (typeof client.pages)['event-templates'][':id']['$get'],
+    200
+  >['template']
+>
+
+const fetchEventTemplates = async (): Promise<EventTemplateSummary[]> => {
+  const response = await client.pages['event-templates'].$get()
+  if (!response.ok) {
+    throw new Error('テンプレートの取得に失敗しました')
+  }
+  const data = await response.json()
+  return data.templates
+}
+
+export const listEventTemplatesQueryOptions = () => ({
+  queryKey: ['event-templates'] as const,
+  queryFn: fetchEventTemplates,
+})
+
+const fetchEventTemplateDetail = async (
+  id: string,
+): Promise<EventTemplateDetail | null> => {
+  const response = await client.pages['event-templates'][':id'].$get({
+    param: { id },
+  })
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw new Error('テンプレートの取得に失敗しました')
+  }
+  const data = await response.json()
+  return data.template
+}
+
+export const getEventTemplateDetailQueryOptions = (id: string) => ({
+  queryKey: ['event-templates', id] as const,
+  queryFn: () => fetchEventTemplateDetail(id),
+})
+
+export const createEventTemplate = async (
+  body: InferRequestType<(typeof client)['event-templates']['$post']>['json'],
+): Promise<void> => {
+  const response = await client['event-templates'].$post({ json: body })
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(
+      'message' in error ? error.message : 'テンプレートの作成に失敗しました',
+    )
+  }
+}
+
+export const updateEventTemplate = async (
+  id: string,
+  body: InferRequestType<
+    (typeof client)['event-templates'][':id']['$put']
+  >['json'],
+): Promise<void> => {
+  const response = await client['event-templates'][':id'].$put({
+    param: { id },
+    json: body,
+  })
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(
+      'message' in error ? error.message : 'テンプレートの更新に失敗しました',
+    )
+  }
+}
+
+export const deleteEventTemplate = async (id: string): Promise<void> => {
+  const response = await client['event-templates'][':id'].$delete({
+    param: { id },
+  })
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(
+      'message' in error ? error.message : 'テンプレートの削除に失敗しました',
+    )
+  }
+}
+
+export const registerEventTemplate = async (
+  id: string,
+  body: InferRequestType<
+    (typeof client)['event-templates'][':id']['register']['$post']
+  >['json'],
+): Promise<void> => {
+  const response = await client['event-templates'][':id']['register'].$post({
+    param: { id },
+    json: body,
+  })
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(
+      'message' in error ? error.message : '一括登録に失敗しました',
+    )
+  }
+}

--- a/packages/app/frontend/routes/event-templates/index.tsx
+++ b/packages/app/frontend/routes/event-templates/index.tsx
@@ -15,18 +15,47 @@ type TemplateListState =
   | { type: 'empty' }
   | { type: 'loaded'; templates: EventTemplateSummary[] }
 
+const buildState = (
+  isPending: boolean,
+  isError: boolean,
+  data: EventTemplateSummary[] | undefined,
+): TemplateListState => {
+  if (isPending) return { type: 'pending' }
+  if (isError) return { type: 'error' }
+  if (!data || data.length === 0) return { type: 'empty' }
+  return { type: 'loaded', templates: data }
+}
+
+const TemplateGrid: React.FC<{ templates: EventTemplateSummary[] }> = ({
+  templates,
+}) => (
+  <div className="grid gap-4 sm:grid-cols-2">
+    {templates.map((tmpl) => {
+      const items: BulkRegisterItem[] = tmpl.items.map((item, index) => ({
+        id: `${tmpl.id}-${index}`,
+        categoryName: item.categoryName,
+        name: item.name,
+        defaultAmount: item.defaultAmount,
+        type: item.type,
+      }))
+      return (
+        <TemplateCard
+          key={tmpl.id}
+          id={tmpl.id}
+          name={tmpl.name}
+          items={items}
+        />
+      )
+    })}
+  </div>
+)
+
 const EventTemplatesPage: React.FC = () => {
   const { data, isPending, isError } = useQuery(
     listEventTemplatesQueryOptions(),
   )
 
-  const state: TemplateListState = isPending
-    ? { type: 'pending' }
-    : isError
-      ? { type: 'error' }
-      : data.length === 0
-        ? { type: 'empty' }
-        : { type: 'loaded', templates: data }
+  const state = buildState(isPending, isError, data)
 
   return (
     <div className="space-y-6">
@@ -57,27 +86,7 @@ const EventTemplatesPage: React.FC = () => {
           </p>
         ))
         .with({ type: 'loaded' }, ({ templates }) => (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {templates.map((tmpl) => {
-              const items: BulkRegisterItem[] = tmpl.items.map(
-                (item, index) => ({
-                  id: `${tmpl.id}-${index}`,
-                  categoryName: item.categoryName,
-                  name: item.name,
-                  defaultAmount: item.defaultAmount,
-                  type: item.type,
-                }),
-              )
-              return (
-                <TemplateCard
-                  key={tmpl.id}
-                  id={tmpl.id}
-                  name={tmpl.name}
-                  items={items}
-                />
-              )
-            })}
-          </div>
+          <TemplateGrid templates={templates} />
         ))
         .exhaustive()}
     </div>

--- a/packages/app/frontend/routes/event-templates/index.tsx
+++ b/packages/app/frontend/routes/event-templates/index.tsx
@@ -1,136 +1,17 @@
 import { Button } from '@frontend/components/ui/button'
+import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { PlusIcon } from 'lucide-react'
 
 import type { BulkRegisterItem } from './-components/template-card'
 import { TemplateCard } from './-components/template-card'
-
-type TemplateSummary = {
-  id: string
-  name: string
-  items: BulkRegisterItem[]
-}
-
-// モックデータ：本番ではAPIから /event-templates を取得する
-const TEMPLATES: TemplateSummary[] = [
-  {
-    id: 'tmpl-1',
-    name: 'ライブ遠征',
-    items: [
-      {
-        id: 'i-1',
-        categoryName: '交通費',
-        name: '新幹線代',
-        defaultAmount: 8000,
-        type: 'expense',
-      },
-      {
-        id: 'i-2',
-        categoryName: '娯楽・グッズ',
-        name: 'ライブグッズ',
-        defaultAmount: 10000,
-        type: 'expense',
-      },
-      {
-        id: 'i-3',
-        categoryName: '外食',
-        name: '遠征ご飯',
-        defaultAmount: 3000,
-        type: 'expense',
-      },
-    ],
-  },
-  {
-    id: 'tmpl-2',
-    name: 'グッズ購入',
-    items: [
-      {
-        id: 'i-4',
-        categoryName: '娯楽・グッズ',
-        name: 'グッズ購入',
-        defaultAmount: 5000,
-        type: 'expense',
-      },
-      {
-        id: 'i-5',
-        categoryName: '交通費',
-        name: '交通費',
-        defaultAmount: 1000,
-        type: 'expense',
-      },
-    ],
-  },
-  {
-    id: 'tmpl-3',
-    name: 'イベント参加（日帰り）',
-    items: [
-      {
-        id: 'i-6',
-        categoryName: '交通費',
-        name: '電車代',
-        defaultAmount: 2000,
-        type: 'expense',
-      },
-      {
-        id: 'i-7',
-        categoryName: '娯楽・グッズ',
-        name: 'チケット',
-        defaultAmount: 8000,
-        type: 'expense',
-      },
-      {
-        id: 'i-8',
-        categoryName: '外食',
-        name: '食事',
-        defaultAmount: 1500,
-        type: 'expense',
-      },
-    ],
-  },
-  {
-    id: 'tmpl-4',
-    name: '給料日',
-    items: [
-      {
-        id: 'i-9',
-        categoryName: '給与・賞与',
-        name: '給与',
-        defaultAmount: 250000,
-        type: 'income',
-      },
-      {
-        id: 'i-10',
-        categoryName: '給与・賞与',
-        name: 'RW手当',
-        defaultAmount: 5000,
-        type: 'income',
-      },
-      {
-        id: 'i-11',
-        categoryName: '社会保険料',
-        name: '厚生年金',
-        defaultAmount: 15000,
-        type: 'expense',
-      },
-      {
-        id: 'i-12',
-        categoryName: '税金',
-        name: '住民税',
-        defaultAmount: 8000,
-        type: 'expense',
-      },
-      {
-        id: 'i-13',
-        categoryName: '税金',
-        name: '市県民税',
-        defaultAmount: 5000,
-        type: 'expense',
-      },
-    ],
-  },
-]
+import { listEventTemplatesQueryOptions } from './-repositories/event-templates'
 
 const EventTemplatesPage: React.FC = () => {
+  const { data, isPending, isError } = useQuery(
+    listEventTemplatesQueryOptions(),
+  )
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -143,16 +24,39 @@ const EventTemplatesPage: React.FC = () => {
         </Button>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2">
-        {TEMPLATES.map((tmpl) => (
-          <TemplateCard
-            key={tmpl.id}
-            id={tmpl.id}
-            name={tmpl.name}
-            items={tmpl.items}
-          />
-        ))}
-      </div>
+      {isPending ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          読み込み中...
+        </p>
+      ) : isError ? (
+        <p className="py-8 text-center text-sm text-destructive">
+          テンプレートの取得に失敗しました
+        </p>
+      ) : data.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          テンプレートがありません
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {data.map((tmpl) => {
+            const items: BulkRegisterItem[] = tmpl.items.map((item, index) => ({
+              id: `${tmpl.id}-${index}`,
+              categoryName: item.categoryName,
+              name: item.name,
+              defaultAmount: item.defaultAmount,
+              type: item.type,
+            }))
+            return (
+              <TemplateCard
+                key={tmpl.id}
+                id={tmpl.id}
+                name={tmpl.name}
+                items={items}
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/app/frontend/routes/event-templates/index.tsx
+++ b/packages/app/frontend/routes/event-templates/index.tsx
@@ -2,15 +2,31 @@ import { Button } from '@frontend/components/ui/button'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { PlusIcon } from 'lucide-react'
+import { match } from 'ts-pattern'
 
 import type { BulkRegisterItem } from './-components/template-card'
 import { TemplateCard } from './-components/template-card'
+import type { EventTemplateSummary } from './-repositories/event-templates'
 import { listEventTemplatesQueryOptions } from './-repositories/event-templates'
+
+type TemplateListState =
+  | { type: 'pending' }
+  | { type: 'error' }
+  | { type: 'empty' }
+  | { type: 'loaded'; templates: EventTemplateSummary[] }
 
 const EventTemplatesPage: React.FC = () => {
   const { data, isPending, isError } = useQuery(
     listEventTemplatesQueryOptions(),
   )
+
+  const state: TemplateListState = isPending
+    ? { type: 'pending' }
+    : isError
+      ? { type: 'error' }
+      : data.length === 0
+        ? { type: 'empty' }
+        : { type: 'loaded', templates: data }
 
   return (
     <div className="space-y-6">
@@ -24,39 +40,46 @@ const EventTemplatesPage: React.FC = () => {
         </Button>
       </div>
 
-      {isPending ? (
-        <p className="py-8 text-center text-sm text-muted-foreground">
-          読み込み中...
-        </p>
-      ) : isError ? (
-        <p className="py-8 text-center text-sm text-destructive">
-          テンプレートの取得に失敗しました
-        </p>
-      ) : data.length === 0 ? (
-        <p className="py-8 text-center text-sm text-muted-foreground">
-          テンプレートがありません
-        </p>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {data.map((tmpl) => {
-            const items: BulkRegisterItem[] = tmpl.items.map((item, index) => ({
-              id: `${tmpl.id}-${index}`,
-              categoryName: item.categoryName,
-              name: item.name,
-              defaultAmount: item.defaultAmount,
-              type: item.type,
-            }))
-            return (
-              <TemplateCard
-                key={tmpl.id}
-                id={tmpl.id}
-                name={tmpl.name}
-                items={items}
-              />
-            )
-          })}
-        </div>
-      )}
+      {match(state)
+        .with({ type: 'pending' }, () => (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            読み込み中...
+          </p>
+        ))
+        .with({ type: 'error' }, () => (
+          <p className="py-8 text-center text-sm text-destructive">
+            テンプレートの取得に失敗しました
+          </p>
+        ))
+        .with({ type: 'empty' }, () => (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            テンプレートがありません
+          </p>
+        ))
+        .with({ type: 'loaded' }, ({ templates }) => (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {templates.map((tmpl) => {
+              const items: BulkRegisterItem[] = tmpl.items.map(
+                (item, index) => ({
+                  id: `${tmpl.id}-${index}`,
+                  categoryName: item.categoryName,
+                  name: item.name,
+                  defaultAmount: item.defaultAmount,
+                  type: item.type,
+                }),
+              )
+              return (
+                <TemplateCard
+                  key={tmpl.id}
+                  id={tmpl.id}
+                  name={tmpl.name}
+                  items={items}
+                />
+              )
+            })}
+          </div>
+        ))
+        .exhaustive()}
     </div>
   )
 }

--- a/packages/app/frontend/routes/event-templates/new/index.tsx
+++ b/packages/app/frontend/routes/event-templates/new/index.tsx
@@ -1,16 +1,53 @@
+import type {
+  CategoryColor,
+  CategoryIconType,
+} from '@frontend/components/category/types'
 import { Button } from '@frontend/components/ui/button'
+import { listCategoriesQueryOptions } from '@frontend/routes/categories/-repositories/categories'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { ArrowLeftIcon, Loader2Icon } from 'lucide-react'
+import { toast } from 'sonner'
 
 import { TemplateFormFields } from '../-components/template-form-fields'
 import { useTemplateForm } from '../-components/use-template-form'
+import { createEventTemplate } from '../-repositories/event-templates'
 
 const EventTemplateNewPage: React.FC = () => {
   const navigate = useNavigate()
-  const form = useTemplateForm({}, async () => {
-    // モック：実際にはAPIを呼び出してテンプレートを作成する
-    await new Promise((resolve) => setTimeout(resolve, 1000))
-    void navigate({ to: '/event-templates' })
+  const queryClient = useQueryClient()
+
+  const { data: categoriesData } = useQuery(listCategoriesQueryOptions())
+
+  const categories = (categoriesData ?? [])
+    .filter((c) => c.type !== 'saving')
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      icon: c.icon as CategoryIconType,
+      color: c.color as CategoryColor,
+    }))
+
+  const mutation = useMutation({
+    mutationFn: createEventTemplate,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['event-templates'] })
+      void navigate({ to: '/event-templates' })
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const form = useTemplateForm({}, async (value) => {
+    await mutation.mutateAsync({
+      name: value.templateName,
+      defaultTransactions: value.items.map((item) => ({
+        categoryId: item.categoryId,
+        name: item.name,
+        amount: parseInt(item.amount, 10),
+      })),
+    })
   })
 
   return (
@@ -32,7 +69,7 @@ const EventTemplateNewPage: React.FC = () => {
           await form.handleSubmit()
         }}
       >
-        <TemplateFormFields form={form} />
+        <TemplateFormFields form={form} categories={categories} />
 
         <form.Subscribe
           selector={(state) => state.isSubmitting}


### PR DESCRIPTION
Fixes: #34

## 概要

issue #34 のフロントエンド実装です。イベントテンプレートの各ページをモックデータからバックエンドAPIに接続しました。

## 変更内容

### 新規追加

- **`-repositories/event-templates.ts`** — イベントテンプレートAPIクライアント
  - `listEventTemplatesQueryOptions()` — 一覧取得（pages API）
  - `getEventTemplateDetailQueryOptions(id)` — 詳細取得（pages API）
  - `createEventTemplate` / `updateEventTemplate` / `deleteEventTemplate` — CRUD（features API）
  - `registerEventTemplate` — 一括登録（features API）

- **`-components/date-picker-field.tsx`** — 日付選択フィールドコンポーネント（register ページの LOC 制限対応で切り出し）

- **`-components/register-items-table.tsx`** — 一括登録の取引項目テーブルコンポーネント（同上）

### 変更

- **`use-template-form.ts`** — `type`（収入/支出）フィールドを削除。バックエンドがカテゴリ種別から自動判定するため不要になった
- **`template-form-item.tsx`** — 種別セレクトを削除し、`categories` プロップスを受け取るよう変更
- **`template-form-fields.tsx`** — `categories` プロップスを追加してフォームアイテムに渡すよう変更
- **各ページ** — モックデータを削除し、TanStack Query + API クライアントに切り替え
  - `index.tsx` — テンプレート一覧
  - `new/index.tsx` — 新規作成（カテゴリAPI連携・`useMutation`）
  - `$id/index.tsx` — 詳細表示・削除
  - `$id/edit/index.tsx` — 編集（カテゴリAPI連携・`useMutation`）
  - `$id/register/index.tsx` — 一括登録（`useMutation`、transactions/events キャッシュ更新）