### PR TITLE
refactor(event-templates): イベントテンプレートのjsonカラムをサブテーブルに移行する

### DIFF
--- a/packages/app/backend/features/categories/repository.ts
+++ b/packages/app/backend/features/categories/repository.ts
@@ -4,7 +4,7 @@ import type { DrizzleDatabase } from '@backend/lib/drizzle'
 import { createCategoryModel } from '@backend/repositories/category'
 import { categoriesTable } from '@backend/schemas/categories'
 import { Result } from '@praha/byethrow'
-import { and, DrizzleQueryError, eq } from 'drizzle-orm'
+import { and, DrizzleQueryError, eq, inArray } from 'drizzle-orm'
 
 import {
   CategoryNotFoundException,
@@ -33,6 +33,27 @@ export const findCategoryById =
 
     const row = results[0]
     return row ? createCategoryModel(row) : undefined
+  }
+
+export const findCategoriesByIds =
+  (db: DrizzleDatabase) =>
+  async (
+    ids: CategoryId[],
+    userId: UserId,
+  ): Promise<Map<CategoryId, Category>> => {
+    if (ids.length === 0) return new Map()
+    const results = await db
+      .select()
+      .from(categoriesTable)
+      .where(
+        and(
+          inArray(categoriesTable.id, ids),
+          eq(categoriesTable.user_id, userId),
+        ),
+      )
+    return new Map(
+      results.map((r) => [r.id as CategoryId, createCategoryModel(r)]),
+    )
   }
 
 export const saveCategory =

--- a/packages/app/backend/features/event-templates/repository.ts
+++ b/packages/app/backend/features/event-templates/repository.ts
@@ -7,33 +7,82 @@ import type {
 import type { Transaction } from '@backend/domains/transaction'
 import type { UserId } from '@backend/domains/user'
 import type { DrizzleDatabase } from '@backend/lib/drizzle'
-import { eventTemplatesTable } from '@backend/schemas/event-templates'
+import {
+  eventTemplateItemsTable,
+  eventTemplatesTable,
+} from '@backend/schemas/event-templates'
 import { eventsTable } from '@backend/schemas/events'
 import { transactionsTable } from '@backend/schemas/transactions'
 import { and, eq } from 'drizzle-orm'
 
-const toEventTemplate = (row: {
-  id: string
-  user_id: string
-  name: string
-  default_transactions: string
-}): EventTemplate => ({
-  id: row.id as EventTemplateId,
-  userId: row.user_id as UserId,
-  name: row.name,
-  defaultTransactions: JSON.parse(
-    row.default_transactions,
-  ) as TemplateTransaction[],
-})
+const groupEventTemplates = (
+  rows: Array<{
+    id: string
+    user_id: string
+    name: string
+    item_event_template_id: string | null
+    item_category_id: string | null
+    item_name: string | null
+    item_amount: number | null
+  }>,
+): EventTemplate[] => {
+  const map = new Map<
+    string,
+    { id: string; user_id: string; name: string; items: TemplateTransaction[] }
+  >()
+  for (const row of rows) {
+    if (!map.has(row.id)) {
+      map.set(row.id, {
+        id: row.id,
+        user_id: row.user_id,
+        name: row.name,
+        items: [],
+      })
+    }
+    if (
+      row.item_category_id !== null &&
+      row.item_name !== null &&
+      row.item_amount !== null
+    ) {
+      const entry = map.get(row.id)
+      if (entry) {
+        entry.items.push({
+          categoryId:
+            row.item_category_id as EventTemplate['defaultTransactions'][number]['categoryId'],
+          name: row.item_name,
+          amount: row.item_amount,
+        })
+      }
+    }
+  }
+  return [...map.values()].map((entry) => ({
+    id: entry.id as EventTemplateId,
+    userId: entry.user_id as UserId,
+    name: entry.name,
+    defaultTransactions: entry.items,
+  }))
+}
 
 export const findEventTemplates =
   (db: DrizzleDatabase) =>
   async (userId: UserId): Promise<EventTemplate[]> => {
-    const results = await db
-      .select()
+    const rows = await db
+      .select({
+        id: eventTemplatesTable.id,
+        user_id: eventTemplatesTable.user_id,
+        name: eventTemplatesTable.name,
+        item_event_template_id: eventTemplateItemsTable.event_template_id,
+        item_category_id: eventTemplateItemsTable.category_id,
+        item_name: eventTemplateItemsTable.name,
+        item_amount: eventTemplateItemsTable.amount,
+      })
       .from(eventTemplatesTable)
+      .leftJoin(
+        eventTemplateItemsTable,
+        eq(eventTemplatesTable.id, eventTemplateItemsTable.event_template_id),
+      )
       .where(eq(eventTemplatesTable.user_id, userId))
-    return results.map(toEventTemplate)
+    return groupEventTemplates(rows)
   }
 
 export const findEventTemplateById =
@@ -42,17 +91,28 @@ export const findEventTemplateById =
     id: EventTemplateId,
     userId: UserId,
   ): Promise<EventTemplate | undefined> => {
-    const results = await db
-      .select()
+    const rows = await db
+      .select({
+        id: eventTemplatesTable.id,
+        user_id: eventTemplatesTable.user_id,
+        name: eventTemplatesTable.name,
+        item_event_template_id: eventTemplateItemsTable.event_template_id,
+        item_category_id: eventTemplateItemsTable.category_id,
+        item_name: eventTemplateItemsTable.name,
+        item_amount: eventTemplateItemsTable.amount,
+      })
       .from(eventTemplatesTable)
+      .leftJoin(
+        eventTemplateItemsTable,
+        eq(eventTemplatesTable.id, eventTemplateItemsTable.event_template_id),
+      )
       .where(
         and(
           eq(eventTemplatesTable.id, id),
           eq(eventTemplatesTable.user_id, userId),
         ),
       )
-    const row = results[0]
-    return row ? toEventTemplate(row) : undefined
+    return groupEventTemplates(rows)[0]
   }
 
 export const saveEventTemplate =
@@ -64,20 +124,32 @@ export const saveEventTemplate =
         id: template.id,
         user_id: template.userId,
         name: template.name,
-        default_transactions: JSON.stringify(template.defaultTransactions),
       })
       .onConflictDoUpdate({
         target: eventTemplatesTable.id,
-        set: {
-          name: template.name,
-          default_transactions: JSON.stringify(template.defaultTransactions),
-        },
+        set: { name: template.name },
       })
+    await db
+      .delete(eventTemplateItemsTable)
+      .where(eq(eventTemplateItemsTable.event_template_id, template.id))
+    if (template.defaultTransactions.length > 0) {
+      await db.insert(eventTemplateItemsTable).values(
+        template.defaultTransactions.map((tx) => ({
+          event_template_id: template.id,
+          category_id: tx.categoryId,
+          name: tx.name,
+          amount: tx.amount,
+        })),
+      )
+    }
   }
 
 export const deleteEventTemplate =
   (db: DrizzleDatabase) =>
   async (id: EventTemplateId): Promise<void> => {
+    await db
+      .delete(eventTemplateItemsTable)
+      .where(eq(eventTemplateItemsTable.event_template_id, id))
     await db.delete(eventTemplatesTable).where(eq(eventTemplatesTable.id, id))
   }
 

--- a/packages/app/backend/features/event-templates/repository.ts
+++ b/packages/app/backend/features/event-templates/repository.ts
@@ -1,3 +1,4 @@
+import type { Category } from '@backend/domains/category'
 import type { Event } from '@backend/domains/event'
 import type {
   EventTemplate,
@@ -7,6 +8,8 @@ import type {
 import type { Transaction } from '@backend/domains/transaction'
 import type { UserId } from '@backend/domains/user'
 import type { DrizzleDatabase } from '@backend/lib/drizzle'
+import { createCategoryModel } from '@backend/repositories/category'
+import { categoriesTable } from '@backend/schemas/categories'
 import {
   eventTemplateItemsTable,
   eventTemplatesTable,
@@ -14,6 +17,17 @@ import {
 import { eventsTable } from '@backend/schemas/events'
 import { transactionsTable } from '@backend/schemas/transactions'
 import { and, eq } from 'drizzle-orm'
+
+export type TemplateTransactionWithCategory = TemplateTransaction & {
+  category: Category
+}
+
+export type EventTemplateWithCategories = Omit<
+  EventTemplate,
+  'defaultTransactions'
+> & {
+  defaultTransactions: TemplateTransactionWithCategory[]
+}
 
 const groupEventTemplates = (
   rows: Array<{
@@ -115,10 +129,87 @@ export const findEventTemplateById =
     return groupEventTemplates(rows)[0]
   }
 
+export const findEventTemplateWithCategoriesById =
+  (db: DrizzleDatabase) =>
+  async (
+    id: EventTemplateId,
+    userId: UserId,
+  ): Promise<EventTemplateWithCategories | undefined> => {
+    const rows = await db
+      .select({
+        id: eventTemplatesTable.id,
+        user_id: eventTemplatesTable.user_id,
+        name: eventTemplatesTable.name,
+        item_category_id: eventTemplateItemsTable.category_id,
+        item_name: eventTemplateItemsTable.name,
+        item_amount: eventTemplateItemsTable.amount,
+        category_id: categoriesTable.id,
+        category_user_id: categoriesTable.user_id,
+        category_type: categoriesTable.type,
+        category_name: categoriesTable.name,
+        category_icon: categoriesTable.icon,
+        category_color: categoriesTable.color,
+      })
+      .from(eventTemplatesTable)
+      .leftJoin(
+        eventTemplateItemsTable,
+        eq(eventTemplatesTable.id, eventTemplateItemsTable.event_template_id),
+      )
+      .leftJoin(
+        categoriesTable,
+        eq(eventTemplateItemsTable.category_id, categoriesTable.id),
+      )
+      .where(
+        and(
+          eq(eventTemplatesTable.id, id),
+          eq(eventTemplatesTable.user_id, userId),
+        ),
+      )
+
+    const first = rows[0]
+    if (first === undefined) return undefined
+
+    const items: TemplateTransactionWithCategory[] = []
+    for (const row of rows) {
+      if (
+        row.item_category_id !== null &&
+        row.item_name !== null &&
+        row.item_amount !== null &&
+        row.category_id !== null &&
+        row.category_user_id !== null &&
+        row.category_type !== null &&
+        row.category_name !== null &&
+        row.category_icon !== null &&
+        row.category_color !== null
+      ) {
+        items.push({
+          categoryId: row.item_category_id as TemplateTransaction['categoryId'],
+          name: row.item_name,
+          amount: row.item_amount,
+          category: createCategoryModel({
+            id: row.category_id,
+            user_id: row.category_user_id,
+            type: row.category_type,
+            name: row.category_name,
+            icon: row.category_icon,
+            color: row.category_color,
+          }),
+        })
+      }
+    }
+
+    return {
+      id: first.id as EventTemplateId,
+      userId: first.user_id as UserId,
+      name: first.name,
+      defaultTransactions: items,
+    }
+  }
+
 export const saveEventTemplate =
   (db: DrizzleDatabase) =>
   async (template: EventTemplate): Promise<void> => {
-    await db
+    const upsertTemplate = db
       .insert(eventTemplatesTable)
       .values({
         id: template.id,
@@ -129,19 +220,27 @@ export const saveEventTemplate =
         target: eventTemplatesTable.id,
         set: { name: template.name },
       })
-    await db
+    const deleteItems = db
       .delete(eventTemplateItemsTable)
       .where(eq(eventTemplateItemsTable.event_template_id, template.id))
-    if (template.defaultTransactions.length > 0) {
-      await db.insert(eventTemplateItemsTable).values(
+
+    if (template.defaultTransactions.length === 0) {
+      await db.batch([upsertTemplate, deleteItems])
+      return
+    }
+
+    await db.batch([
+      upsertTemplate,
+      deleteItems,
+      db.insert(eventTemplateItemsTable).values(
         template.defaultTransactions.map((tx) => ({
           event_template_id: template.id,
           category_id: tx.categoryId,
           name: tx.name,
           amount: tx.amount,
         })),
-      )
-    }
+      ),
+    ])
   }
 
 export const deleteEventTemplate =

--- a/packages/app/backend/features/event-templates/route.test.ts
+++ b/packages/app/backend/features/event-templates/route.test.ts
@@ -7,7 +7,10 @@ import {
   SESSION_JWT_AGE,
 } from '@backend/lib/session-config'
 import { categoriesTable } from '@backend/schemas/categories'
-import { eventTemplatesTable } from '@backend/schemas/event-templates'
+import {
+  eventTemplateItemsTable,
+  eventTemplatesTable,
+} from '@backend/schemas/event-templates'
 import { sessionsTable } from '@backend/schemas/sessions'
 import { usersTable } from '@backend/schemas/users'
 import { env } from 'cloudflare:test'
@@ -95,12 +98,15 @@ describe('イベントテンプレートAPI', () => {
       id: `tpl-${ulid()}`,
       user_id: userId,
       name: '旅行テンプレート',
-      default_transactions: JSON.stringify([
-        { categoryId, name: '交通費', amount: 10000 },
-      ]),
       ...overrides,
     }
     await db.insert(eventTemplatesTable).values(template)
+    await db.insert(eventTemplateItemsTable).values({
+      event_template_id: template.id,
+      category_id: categoryId,
+      name: '交通費',
+      amount: 10000,
+    })
     return template
   }
 

--- a/packages/app/backend/features/event-templates/route.ts
+++ b/packages/app/backend/features/event-templates/route.ts
@@ -1,6 +1,6 @@
 import type { CategoryId } from '@backend/domains/category'
 import type { EventTemplateId } from '@backend/domains/event-template'
-import { findCategoryById } from '@backend/features/categories/repository'
+import { findCategoriesByIds } from '@backend/features/categories/repository'
 import { sessionMiddleware } from '@backend/features/session/middleware'
 import { zValidator } from '@hono/zod-validator'
 import { Result } from '@praha/byethrow'
@@ -62,7 +62,7 @@ const app = new Hono<{ Bindings: Env }>()
       const db = c.get('db')
 
       const workflow = buildCreateEventTemplateWorkflow({
-        findCategoryById: findCategoryById(db),
+        findCategoriesByIds: findCategoriesByIds(db),
       })
 
       const result = await workflow({
@@ -104,7 +104,7 @@ const app = new Hono<{ Bindings: Env }>()
 
       const workflow = buildUpdateEventTemplateWorkflow({
         findEventTemplateById: findEventTemplateById(db),
-        findCategoryById: findCategoryById(db),
+        findCategoriesByIds: findCategoriesByIds(db),
       })
 
       const result = await workflow({
@@ -175,7 +175,7 @@ const app = new Hono<{ Bindings: Env }>()
 
       const workflow = buildRegisterEventTemplateWorkflow({
         findEventTemplateById: findEventTemplateById(db),
-        findCategoryById: findCategoryById(db),
+        findCategoriesByIds: findCategoriesByIds(db),
       })
 
       const result = await workflow({

--- a/packages/app/backend/features/event-templates/route.ts
+++ b/packages/app/backend/features/event-templates/route.ts
@@ -10,6 +10,7 @@ import { EventTemplateNotFoundException } from './exceptions'
 import {
   deleteEventTemplate,
   findEventTemplateById,
+  findEventTemplateWithCategoriesById,
   saveEventTemplate,
   saveEventWithTransactions,
 } from './repository'
@@ -174,8 +175,8 @@ const app = new Hono<{ Bindings: Env }>()
       const db = c.get('db')
 
       const workflow = buildRegisterEventTemplateWorkflow({
-        findEventTemplateById: findEventTemplateById(db),
-        findCategoriesByIds: findCategoriesByIds(db),
+        findEventTemplateWithCategoriesById:
+          findEventTemplateWithCategoriesById(db),
       })
 
       const result = await workflow({

--- a/packages/app/backend/features/event-templates/workflows/create.test.ts
+++ b/packages/app/backend/features/event-templates/workflows/create.test.ts
@@ -22,7 +22,8 @@ describe('buildCreateEventTemplateWorkflow', () => {
   describe('正常系 - テンプレートを作成できる', () => {
     const category = makeCategory('expense')
     const workflow = buildCreateEventTemplateWorkflow({
-      findCategoryById: () => Promise.resolve(category),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, category]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -56,7 +57,7 @@ describe('buildCreateEventTemplateWorkflow', () => {
 
   describe('異常系 - カテゴリが存在しない場合は失敗する', () => {
     const workflow = buildCreateEventTemplateWorkflow({
-      findCategoryById: () => Promise.resolve(undefined),
+      findCategoriesByIds: () => Promise.resolve(new Map()),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -91,7 +92,8 @@ describe('buildCreateEventTemplateWorkflow', () => {
   describe('異常系 - 積立カテゴリを指定した場合は失敗する', () => {
     const savingCategory = makeCategory('saving')
     const workflow = buildCreateEventTemplateWorkflow({
-      findCategoryById: () => Promise.resolve(savingCategory),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, savingCategory]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>

--- a/packages/app/backend/features/event-templates/workflows/create.ts
+++ b/packages/app/backend/features/event-templates/workflows/create.ts
@@ -50,10 +50,10 @@ export type EventTemplateCreatedEvent = {
 // MARK: effects
 
 type Effects = {
-  findCategoryById: (
-    id: CategoryId,
+  findCategoriesByIds: (
+    ids: CategoryId[],
     userId: UserId,
-  ) => Promise<Category | undefined>
+  ) => Promise<Map<CategoryId, Category>>
 }
 
 // MARK: workflow type
@@ -75,12 +75,13 @@ const resolveCategories =
     CategoriesResolved,
     EventTemplateValidationException
   > => {
-    // FIXME: #39 にて修正 - forループ内でDBクエリが発生する
+    const ids = command.input.defaultTransactions.map((tx) => tx.categoryId)
+    const categoryMap = await effects.findCategoriesByIds(
+      ids,
+      command.context.userId,
+    )
     for (const tx of command.input.defaultTransactions) {
-      const category = await effects.findCategoryById(
-        tx.categoryId,
-        command.context.userId,
-      )
+      const category = categoryMap.get(tx.categoryId)
       if (!category) {
         return Result.fail(
           new EventTemplateValidationException(

--- a/packages/app/backend/features/event-templates/workflows/register.test.ts
+++ b/packages/app/backend/features/event-templates/workflows/register.test.ts
@@ -1,8 +1,5 @@
 import type { Category, CategoryId } from '@backend/domains/category'
-import type {
-  EventTemplate,
-  EventTemplateId,
-} from '@backend/domains/event-template'
+import type { EventTemplateId } from '@backend/domains/event-template'
 import type { UserId } from '@backend/domains/user'
 import { Result } from '@praha/byethrow'
 import { ulid } from 'ulid'
@@ -12,6 +9,7 @@ import {
   EventTemplateNotFoundException,
   EventTemplateValidationException,
 } from '../exceptions'
+import type { EventTemplateWithCategories } from '../repository'
 import { buildRegisterEventTemplateWorkflow } from './register'
 
 const userId = `usr-${ulid()}` as UserId
@@ -25,24 +23,26 @@ const makeCategory = (type: Category['type']): Category => ({
   color: 'red',
 })
 
-const makeTemplate = (
-  overrides: Partial<EventTemplate> = {},
-): EventTemplate => ({
+const makeTemplateWithCategories = (
+  categories: Category[],
+): EventTemplateWithCategories => ({
   id: `tpl-${ulid()}` as EventTemplateId,
   userId,
   name: '旅行テンプレート',
-  defaultTransactions: [],
-  ...overrides,
+  defaultTransactions: categories.map((category) => ({
+    categoryId: category.id,
+    name: 'デフォルト項目',
+    amount: 1000,
+    category,
+  })),
 })
 
 describe('buildRegisterEventTemplateWorkflow', () => {
   describe('正常系 - イベントとトランザクションを生成できる', () => {
     const category = makeCategory('expense')
-    const template = makeTemplate()
+    const template = makeTemplateWithCategories([category])
     const workflow = buildRegisterEventTemplateWorkflow({
-      findEventTemplateById: () => Promise.resolve(template),
-      findCategoriesByIds: (ids) =>
-        Promise.resolve(new Map(ids.map((id) => [id, category]))),
+      findEventTemplateWithCategoriesById: () => Promise.resolve(template),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -83,11 +83,9 @@ describe('buildRegisterEventTemplateWorkflow', () => {
 
   describe('正常系 - 収入カテゴリはincomeとなること', () => {
     const incomeCategory = makeCategory('income')
-    const template = makeTemplate()
+    const template = makeTemplateWithCategories([incomeCategory])
     const workflow = buildRegisterEventTemplateWorkflow({
-      findEventTemplateById: () => Promise.resolve(template),
-      findCategoriesByIds: (ids) =>
-        Promise.resolve(new Map(ids.map((id) => [id, incomeCategory]))),
+      findEventTemplateWithCategoriesById: () => Promise.resolve(template),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -113,8 +111,7 @@ describe('buildRegisterEventTemplateWorkflow', () => {
 
   describe('異常系 - テンプレートが存在しない場合は失敗する', () => {
     const workflow = buildRegisterEventTemplateWorkflow({
-      findEventTemplateById: () => Promise.resolve(undefined),
-      findCategoriesByIds: () => Promise.resolve(new Map()),
+      findEventTemplateWithCategoriesById: () => Promise.resolve(undefined),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -144,10 +141,9 @@ describe('buildRegisterEventTemplateWorkflow', () => {
   })
 
   describe('異常系 - カテゴリが存在しない場合は失敗する', () => {
-    const template = makeTemplate()
+    const template = makeTemplateWithCategories([])
     const workflow = buildRegisterEventTemplateWorkflow({
-      findEventTemplateById: () => Promise.resolve(template),
-      findCategoriesByIds: () => Promise.resolve(new Map()),
+      findEventTemplateWithCategoriesById: () => Promise.resolve(template),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>

--- a/packages/app/backend/features/event-templates/workflows/register.test.ts
+++ b/packages/app/backend/features/event-templates/workflows/register.test.ts
@@ -41,7 +41,8 @@ describe('buildRegisterEventTemplateWorkflow', () => {
     const template = makeTemplate()
     const workflow = buildRegisterEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(category),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, category]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -85,7 +86,8 @@ describe('buildRegisterEventTemplateWorkflow', () => {
     const template = makeTemplate()
     const workflow = buildRegisterEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(incomeCategory),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, incomeCategory]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -112,7 +114,7 @@ describe('buildRegisterEventTemplateWorkflow', () => {
   describe('異常系 - テンプレートが存在しない場合は失敗する', () => {
     const workflow = buildRegisterEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(undefined),
-      findCategoryById: () => Promise.resolve(undefined),
+      findCategoriesByIds: () => Promise.resolve(new Map()),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -145,7 +147,7 @@ describe('buildRegisterEventTemplateWorkflow', () => {
     const template = makeTemplate()
     const workflow = buildRegisterEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(undefined),
+      findCategoriesByIds: () => Promise.resolve(new Map()),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>

--- a/packages/app/backend/features/event-templates/workflows/register.ts
+++ b/packages/app/backend/features/event-templates/workflows/register.ts
@@ -116,7 +116,7 @@ const resolveTemplate =
     })
   }
 
-const resolveCategories = (
+const validateItems = (
   resolved: TemplateResolved,
 ): Result.ResultAsync<CategoriesResolved, EventTemplateValidationException> => {
   const categoryMap = new Map(
@@ -194,6 +194,6 @@ export const buildRegisterEventTemplateWorkflow =
     Result.pipe(
       Result.succeed(command),
       Result.andThen(resolveTemplate(effects)),
-      Result.andThen(resolveCategories),
+      Result.andThen(validateItems),
       Result.map(buildRegistrationData),
     )

--- a/packages/app/backend/features/event-templates/workflows/register.ts
+++ b/packages/app/backend/features/event-templates/workflows/register.ts
@@ -1,10 +1,7 @@
-import type { Category, CategoryId } from '@backend/domains/category'
+import type { Category } from '@backend/domains/category'
 import type { Event } from '@backend/domains/event'
 import { createEvent } from '@backend/domains/event'
-import type {
-  EventTemplate,
-  EventTemplateId,
-} from '@backend/domains/event-template'
+import type { EventTemplateId } from '@backend/domains/event-template'
 import type { Transaction, TransactionType } from '@backend/domains/transaction'
 import { createTransaction } from '@backend/domains/transaction'
 import type { UserId } from '@backend/domains/user'
@@ -15,6 +12,10 @@ import {
   EventTemplateNotFoundException,
   EventTemplateValidationException,
 } from '../exceptions'
+import type {
+  EventTemplateWithCategories,
+  TemplateTransactionWithCategory,
+} from '../repository'
 
 // MARK: command
 
@@ -23,7 +24,7 @@ export type RegisterEventTemplateCommand = {
     id: EventTemplateId
     occurredOn: string
     items: Array<{
-      categoryId: CategoryId
+      categoryId: TemplateTransactionWithCategory['categoryId']
       name: string
       amount: number
     }>
@@ -39,21 +40,21 @@ type TemplateResolved = {
   input: {
     occurredOn: string
     items: Array<{
-      categoryId: CategoryId
+      categoryId: TemplateTransactionWithCategory['categoryId']
       name: string
       amount: number
     }>
   }
   context: {
     userId: UserId
-    template: EventTemplate
+    template: EventTemplateWithCategories
   }
 }
 
 type CategoriesResolved = {
   context: {
     userId: UserId
-    template: EventTemplate
+    template: EventTemplateWithCategories
     occurredOn: string
     items: Array<{
       category: Category
@@ -73,14 +74,10 @@ export type EventTemplateRegisteredEvent = {
 // MARK: effects
 
 type Effects = {
-  findEventTemplateById: (
+  findEventTemplateWithCategoriesById: (
     id: EventTemplateId,
     userId: UserId,
-  ) => Promise<EventTemplate | undefined>
-  findCategoriesByIds: (
-    ids: CategoryId[],
-    userId: UserId,
-  ) => Promise<Map<CategoryId, Category>>
+  ) => Promise<EventTemplateWithCategories | undefined>
 }
 
 // MARK: workflow type
@@ -99,7 +96,7 @@ const resolveTemplate =
   async (
     command: RegisterEventTemplateCommand,
   ): Result.ResultAsync<TemplateResolved, EventTemplateNotFoundException> => {
-    const template = await effects.findEventTemplateById(
+    const template = await effects.findEventTemplateWithCategoriesById(
       command.input.id,
       command.context.userId,
     )
@@ -119,47 +116,47 @@ const resolveTemplate =
     })
   }
 
-const resolveCategories =
-  (effects: Effects) =>
-  async (
-    resolved: TemplateResolved,
-  ): Result.ResultAsync<
-    CategoriesResolved,
-    EventTemplateValidationException
-  > => {
-    const ids = resolved.input.items.map((item) => item.categoryId)
-    const categoryMap = await effects.findCategoriesByIds(
-      ids,
-      resolved.context.userId,
-    )
+const resolveCategories = (
+  resolved: TemplateResolved,
+): Result.ResultAsync<CategoriesResolved, EventTemplateValidationException> => {
+  const categoryMap = new Map(
+    resolved.context.template.defaultTransactions.map((tx) => [
+      tx.categoryId,
+      tx.category,
+    ]),
+  )
 
-    const resolvedItems: Array<{
-      category: Category
-      name: string
-      amount: number
-    }> = []
+  const resolvedItems: Array<{
+    category: Category
+    name: string
+    amount: number
+  }> = []
 
-    for (const item of resolved.input.items) {
-      const category = categoryMap.get(item.categoryId)
-      if (!category) {
-        return Result.fail(
+  for (const item of resolved.input.items) {
+    const category = categoryMap.get(item.categoryId)
+    if (!category) {
+      return Promise.resolve(
+        Result.fail(
           new EventTemplateValidationException(
             `カテゴリが見つかりません: ${item.categoryId}`,
           ),
-        )
-      }
-      resolvedItems.push({ category, name: item.name, amount: item.amount })
+        ),
+      )
     }
+    resolvedItems.push({ category, name: item.name, amount: item.amount })
+  }
 
-    return Result.succeed({
+  return Promise.resolve(
+    Result.succeed({
       context: {
         userId: resolved.context.userId,
         template: resolved.context.template,
         occurredOn: resolved.input.occurredOn,
         items: resolvedItems,
       },
-    })
-  }
+    }),
+  )
+}
 
 const resolveTransactionType = (
   categoryType: Category['type'],
@@ -197,6 +194,6 @@ export const buildRegisterEventTemplateWorkflow =
     Result.pipe(
       Result.succeed(command),
       Result.andThen(resolveTemplate(effects)),
-      Result.andThen(resolveCategories(effects)),
+      Result.andThen(resolveCategories),
       Result.map(buildRegistrationData),
     )

--- a/packages/app/backend/features/event-templates/workflows/register.ts
+++ b/packages/app/backend/features/event-templates/workflows/register.ts
@@ -77,10 +77,10 @@ type Effects = {
     id: EventTemplateId,
     userId: UserId,
   ) => Promise<EventTemplate | undefined>
-  findCategoryById: (
-    id: CategoryId,
+  findCategoriesByIds: (
+    ids: CategoryId[],
     userId: UserId,
-  ) => Promise<Category | undefined>
+  ) => Promise<Map<CategoryId, Category>>
 }
 
 // MARK: workflow type
@@ -127,18 +127,20 @@ const resolveCategories =
     CategoriesResolved,
     EventTemplateValidationException
   > => {
+    const ids = resolved.input.items.map((item) => item.categoryId)
+    const categoryMap = await effects.findCategoriesByIds(
+      ids,
+      resolved.context.userId,
+    )
+
     const resolvedItems: Array<{
       category: Category
       name: string
       amount: number
     }> = []
 
-    // FIXME: #39 にて修正 - forループ内でDBクエリが発生する。外部キー制約で解決可能
     for (const item of resolved.input.items) {
-      const category = await effects.findCategoryById(
-        item.categoryId,
-        resolved.context.userId,
-      )
+      const category = categoryMap.get(item.categoryId)
       if (!category) {
         return Result.fail(
           new EventTemplateValidationException(

--- a/packages/app/backend/features/event-templates/workflows/update.test.ts
+++ b/packages/app/backend/features/event-templates/workflows/update.test.ts
@@ -45,7 +45,8 @@ describe('buildUpdateEventTemplateWorkflow', () => {
     })
     const workflow = buildUpdateEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(category),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, category]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -82,7 +83,8 @@ describe('buildUpdateEventTemplateWorkflow', () => {
     })
     const workflow = buildUpdateEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(newCategory),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, newCategory]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -117,7 +119,7 @@ describe('buildUpdateEventTemplateWorkflow', () => {
   describe('異常系 - テンプレートが存在しない場合は失敗する', () => {
     const workflow = buildUpdateEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(undefined),
-      findCategoryById: () => Promise.resolve(undefined),
+      findCategoriesByIds: () => Promise.resolve(new Map()),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -147,7 +149,7 @@ describe('buildUpdateEventTemplateWorkflow', () => {
     })
     const workflow = buildUpdateEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(undefined),
+      findCategoriesByIds: () => Promise.resolve(new Map()),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>
@@ -183,7 +185,8 @@ describe('buildUpdateEventTemplateWorkflow', () => {
     const template = makeTemplate()
     const workflow = buildUpdateEventTemplateWorkflow({
       findEventTemplateById: () => Promise.resolve(template),
-      findCategoryById: () => Promise.resolve(savingCategory),
+      findCategoriesByIds: (ids) =>
+        Promise.resolve(new Map(ids.map((id) => [id, savingCategory]))),
     })
 
     let result: Awaited<ReturnType<typeof workflow>>

--- a/packages/app/backend/features/event-templates/workflows/update.ts
+++ b/packages/app/backend/features/event-templates/workflows/update.ts
@@ -57,10 +57,10 @@ type Effects = {
     id: EventTemplateId,
     userId: UserId,
   ) => Promise<EventTemplate | undefined>
-  findCategoryById: (
-    id: CategoryId,
+  findCategoriesByIds: (
+    ids: CategoryId[],
     userId: UserId,
-  ) => Promise<Category | undefined>
+  ) => Promise<Map<CategoryId, Category>>
 }
 
 // MARK: workflow type
@@ -109,12 +109,13 @@ const resolveCategories =
   async (
     resolved: TemplateResolved,
   ): Result.ResultAsync<TemplateResolved, EventTemplateValidationException> => {
-    // FIXME: #39 にて修正 - forループ内でDBクエリが発生する
+    const ids = resolved.input.defaultTransactions.map((tx) => tx.categoryId)
+    const categoryMap = await effects.findCategoriesByIds(
+      ids,
+      resolved.context.userId,
+    )
     for (const tx of resolved.input.defaultTransactions) {
-      const category = await effects.findCategoryById(
-        tx.categoryId,
-        resolved.context.userId,
-      )
+      const category = categoryMap.get(tx.categoryId)
       if (!category) {
         return Result.fail(
           new EventTemplateValidationException(

--- a/packages/app/backend/pages/event-templates/repository.ts
+++ b/packages/app/backend/pages/event-templates/repository.ts
@@ -1,12 +1,12 @@
-import type {
-  EventTemplateId,
-  TemplateTransaction,
-} from '@backend/domains/event-template'
+import type { EventTemplateId } from '@backend/domains/event-template'
 import type { UserId } from '@backend/domains/user'
 import type { DrizzleDatabase } from '@backend/lib/drizzle'
 import { categoriesTable } from '@backend/schemas/categories'
-import { eventTemplatesTable } from '@backend/schemas/event-templates'
-import { eq, inArray } from 'drizzle-orm'
+import {
+  eventTemplateItemsTable,
+  eventTemplatesTable,
+} from '@backend/schemas/event-templates'
+import { and, eq } from 'drizzle-orm'
 
 export type EventTemplateSummaryItem = {
   categoryName: string
@@ -35,80 +35,56 @@ export type EventTemplateDetailRow = {
   items: EventTemplateDetailItem[]
 }
 
-type CategoryRow = {
-  id: string
-  name: string
-  type: string
-}
-
-const buildCategoryMap = (
-  categories: CategoryRow[],
-): Map<string, CategoryRow> => {
-  const map = new Map<string, CategoryRow>()
-  for (const cat of categories) {
-    map.set(cat.id, cat)
-  }
-  return map
-}
-
 const resolveCategoryType = (type: string): 'income' | 'expense' =>
   type === 'income' ? 'income' : 'expense'
 
 export const findEventTemplateSummaries =
   (db: DrizzleDatabase) =>
   async (userId: UserId): Promise<EventTemplateSummaryRow[]> => {
-    const templateRows = await db
-      .select()
+    const rows = await db
+      .select({
+        id: eventTemplatesTable.id,
+        name: eventTemplatesTable.name,
+        item_category_id: eventTemplateItemsTable.category_id,
+        item_name: eventTemplateItemsTable.name,
+        item_amount: eventTemplateItemsTable.amount,
+        category_name: categoriesTable.name,
+        category_type: categoriesTable.type,
+      })
       .from(eventTemplatesTable)
+      .leftJoin(
+        eventTemplateItemsTable,
+        eq(eventTemplatesTable.id, eventTemplateItemsTable.event_template_id),
+      )
+      .leftJoin(
+        categoriesTable,
+        eq(eventTemplateItemsTable.category_id, categoriesTable.id),
+      )
       .where(eq(eventTemplatesTable.user_id, userId))
 
-    if (templateRows.length === 0) {
-      return []
+    const map = new Map<string, EventTemplateSummaryRow>()
+    for (const row of rows) {
+      if (!map.has(row.id)) {
+        map.set(row.id, { id: row.id, name: row.name, items: [] })
+      }
+      const entry = map.get(row.id)
+      if (
+        entry !== undefined &&
+        row.item_category_id !== null &&
+        row.item_name !== null &&
+        row.item_amount !== null &&
+        row.category_name !== null &&
+        row.category_type !== null
+      ) {
+        entry.items.push({
+          categoryName: row.category_name,
+          name: row.item_name,
+          defaultAmount: row.item_amount,
+          type: resolveCategoryType(row.category_type),
+        })
+      }
     }
-
-    const transactionsByTemplateId = new Map(
-      templateRows.map((row) => [
-        row.id,
-        JSON.parse(row.default_transactions) as TemplateTransaction[],
-      ]),
-    )
-
-    // FIXME: #39 にて修正 - default_transactionsがJSONカラムのためSQLのJOINが使えず、アプリケーションレベルでJOINしている
-    const categoryIds = [
-      ...new Set(
-        [...transactionsByTemplateId.values()].flatMap((transactions) =>
-          transactions.map((tx) => tx.categoryId),
-        ),
-      ),
-    ]
-
-    const categoryRows =
-      categoryIds.length > 0
-        ? await db
-            .select({
-              id: categoriesTable.id,
-              name: categoriesTable.name,
-              type: categoriesTable.type,
-            })
-            .from(categoriesTable)
-            .where(inArray(categoriesTable.id, categoryIds))
-        : []
-
-    const categoryMap = buildCategoryMap(categoryRows)
-
-    return templateRows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      items: (transactionsByTemplateId.get(row.id) ?? []).map((tx) => {
-        const cat = categoryMap.get(tx.categoryId)
-        return {
-          categoryName: cat?.name ?? tx.categoryId,
-          name: tx.name,
-          defaultAmount: tx.amount,
-          type: resolveCategoryType(cat?.type ?? 'expense'),
-        }
-      }),
-    }))
+    return [...map.values()]
   }
 
 export const findEventTemplateDetail =
@@ -117,49 +93,58 @@ export const findEventTemplateDetail =
     id: EventTemplateId,
     userId: UserId,
   ): Promise<EventTemplateDetailRow | undefined> => {
-    const results = await db
-      .select()
+    const rows = await db
+      .select({
+        id: eventTemplatesTable.id,
+        name: eventTemplatesTable.name,
+        item_category_id: eventTemplateItemsTable.category_id,
+        item_name: eventTemplateItemsTable.name,
+        item_amount: eventTemplateItemsTable.amount,
+        category_name: categoriesTable.name,
+        category_type: categoriesTable.type,
+      })
       .from(eventTemplatesTable)
-      .where(eq(eventTemplatesTable.id, id))
+      .leftJoin(
+        eventTemplateItemsTable,
+        eq(eventTemplatesTable.id, eventTemplateItemsTable.event_template_id),
+      )
+      .leftJoin(
+        categoriesTable,
+        eq(eventTemplateItemsTable.category_id, categoriesTable.id),
+      )
+      .where(
+        and(
+          eq(eventTemplatesTable.id, id),
+          eq(eventTemplatesTable.user_id, userId),
+        ),
+      )
 
-    const row = results[0]
-    if (!row || row.user_id !== userId) {
+    if (rows.length === 0) {
       return undefined
     }
 
-    const transactions = JSON.parse(
-      row.default_transactions,
-    ) as TemplateTransaction[]
-
-    // FIXME: #39 にて修正 - default_transactionsがJSONカラムのためSQLのJOINが使えず、アプリケーションレベルでJOINしている
-    const categoryIds = [...new Set(transactions.map((tx) => tx.categoryId))]
-
-    const categoryRows =
-      categoryIds.length > 0
-        ? await db
-            .select({
-              id: categoriesTable.id,
-              name: categoriesTable.name,
-              type: categoriesTable.type,
-            })
-            .from(categoriesTable)
-            .where(inArray(categoriesTable.id, categoryIds))
-        : []
-
-    const categoryMap = buildCategoryMap(categoryRows)
-
-    return {
-      id: row.id,
-      name: row.name,
-      items: transactions.map((tx) => {
-        const cat = categoryMap.get(tx.categoryId)
-        return {
-          categoryId: tx.categoryId,
-          categoryName: cat?.name ?? tx.categoryId,
-          name: tx.name,
-          defaultAmount: tx.amount,
-          type: resolveCategoryType(cat?.type ?? 'expense'),
-        }
-      }),
+    const first = rows[0]
+    if (first === undefined) {
+      return undefined
     }
+    const items: EventTemplateDetailItem[] = []
+    for (const row of rows) {
+      if (
+        row.item_category_id !== null &&
+        row.item_name !== null &&
+        row.item_amount !== null &&
+        row.category_name !== null &&
+        row.category_type !== null
+      ) {
+        items.push({
+          categoryId: row.item_category_id,
+          categoryName: row.category_name,
+          name: row.item_name,
+          defaultAmount: row.item_amount,
+          type: resolveCategoryType(row.category_type),
+        })
+      }
+    }
+
+    return { id: first.id, name: first.name, items }
   }

--- a/packages/app/backend/schemas/event-templates.ts
+++ b/packages/app/backend/schemas/event-templates.ts
@@ -1,5 +1,6 @@
-import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
+import { categoriesTable } from './categories'
 import { usersTable } from './users'
 
 export const eventTemplatesTable = sqliteTable('event_templates', {
@@ -8,6 +9,19 @@ export const eventTemplatesTable = sqliteTable('event_templates', {
     .notNull()
     .references(() => usersTable.id),
   name: text().notNull(),
-  /** JSON: TemplateTransaction[] */
-  default_transactions: text().notNull(),
 })
+
+export const eventTemplateItemsTable = sqliteTable(
+  'event_template_items',
+  {
+    event_template_id: text()
+      .notNull()
+      .references(() => eventTemplatesTable.id),
+    category_id: text()
+      .notNull()
+      .references(() => categoriesTable.id),
+    name: text().notNull(),
+    amount: integer().notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.event_template_id, t.category_id] })],
+)

--- a/packages/app/drizzle/0000_useful_phalanx.sql
+++ b/packages/app/drizzle/0000_useful_phalanx.sql
@@ -28,11 +28,20 @@ CREATE TABLE `categories` (
 	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint
+CREATE TABLE `event_template_items` (
+	`event_template_id` text NOT NULL,
+	`category_id` text NOT NULL,
+	`name` text NOT NULL,
+	`amount` integer NOT NULL,
+	PRIMARY KEY(`event_template_id`, `category_id`),
+	FOREIGN KEY (`event_template_id`) REFERENCES `event_templates`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`category_id`) REFERENCES `categories`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
 CREATE TABLE `event_templates` (
 	`id` text PRIMARY KEY NOT NULL,
 	`user_id` text NOT NULL,
 	`name` text NOT NULL,
-	`default_transactions` text NOT NULL,
 	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
 );
 --> statement-breakpoint

--- a/packages/app/drizzle/meta/0000_snapshot.json
+++ b/packages/app/drizzle/meta/0000_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "cf9fc053-5ca7-4b42-9751-9d7edaa1d421",
+  "id": "a31ba3ab-abf9-450c-a119-2cc271641180",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "tables": {
     "auth_states": {
@@ -209,6 +209,79 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
+    "event_template_items": {
+      "name": "event_template_items",
+      "columns": {
+        "event_template_id": {
+          "name": "event_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_template_items_event_template_id_event_templates_id_fk": {
+          "name": "event_template_items_event_template_id_event_templates_id_fk",
+          "tableFrom": "event_template_items",
+          "tableTo": "event_templates",
+          "columnsFrom": [
+            "event_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_template_items_category_id_categories_id_fk": {
+          "name": "event_template_items_category_id_categories_id_fk",
+          "tableFrom": "event_template_items",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_template_items_event_template_id_category_id_pk": {
+          "columns": [
+            "event_template_id",
+            "category_id"
+          ],
+          "name": "event_template_items_event_template_id_category_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
     "event_templates": {
       "name": "event_templates",
       "columns": {
@@ -228,13 +301,6 @@
         },
         "name": {
           "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
-        },
-        "default_transactions": {
-          "name": "default_transactions",
           "type": "text",
           "primaryKey": false,
           "notNull": true,

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "6",
-      "when": 1775283470700,
-      "tag": "0000_lucky_doctor_spectrum",
+      "when": 1775395727081,
+      "tag": "0000_useful_phalanx",
       "breakpoints": true
     }
   ]


### PR DESCRIPTION
Fixes: #39

default_transactionsカラム（JSONテキスト）を廃止し、event_template_itemsサブテーブルに正規化。
複合主キー(event_template_id, category_id)によりDB制約レベルでcategoryId重複を防止し、
SQLのJOINを使用可能にすることでN+1クエリ問題を解消した。

https://claude.ai/code/session_01ChqLfyTdyzYHR6xZs3y9uE